### PR TITLE
Add authentication interceptor when OkHttpClient provided to builder.

### DIFF
--- a/aws-android-sdk-appsync/src/main/java/com/amazonaws/mobileconnectors/appsync/AWSAppSyncClient.java
+++ b/aws-android-sdk-appsync/src/main/java/com/amazonaws/mobileconnectors/appsync/AWSAppSyncClient.java
@@ -82,13 +82,16 @@ public class AWSAppSyncClient {
             throw new RuntimeException("Client requires credentials. Please use #apiKey() #credentialsProvider() or #cognitoUserPoolsAuthProvider() to set the credentials.");
         }
 
-        OkHttpClient okHttpClient = builder.mOkHttpClient;
-
-        if (okHttpClient == null) {
-            okHttpClient = new OkHttpClient.Builder()
-                    .addInterceptor(appSyncSigV4SignerInterceptor)
-                    .build();
+        OkHttpClient.Builder okHttpClientBuilder;
+        if (builder.mOkHttpClient == null) {
+            okHttpClientBuilder = new OkHttpClient.Builder();
+        } else {
+            okHttpClientBuilder = builder.mOkHttpClient.newBuilder();
         }
+
+        OkHttpClient okHttpClient = okHttpClientBuilder
+                .addInterceptor(appSyncSigV4SignerInterceptor)
+                .build();
 
         AppSyncMutationsSqlHelper mutationsSqlHelper = new AppSyncMutationsSqlHelper(builder.mContext, defaultMutationSqlStoreName);
         AppSyncMutationSqlCacheOperations sqlCacheOperations = new AppSyncMutationSqlCacheOperations(mutationsSqlHelper);


### PR DESCRIPTION
*Issue #, if available:* https://github.com/awslabs/aws-mobile-appsync-sdk-android/issues/3

*Description of changes:* If OkHttpClient was set in builder add authentication interceptor to it.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
