### PR TITLE
MqttSubscriptionClient: connection lost (issue #22)

### DIFF
--- a/aws-android-sdk-appsync/src/main/java/com/amazonaws/mobileconnectors/appsync/subscription/RealSubscriptionManager.java
+++ b/aws-android-sdk-appsync/src/main/java/com/amazonaws/mobileconnectors/appsync/subscription/RealSubscriptionManager.java
@@ -190,7 +190,9 @@ public class RealSubscriptionManager implements SubscriptionManager {
                 public void onError(Exception e) {
                     Map<SubscriptionObject, AppSyncSubscriptionCall.Callback> unsubscribeMap = new HashMap<>();
                     for (String topic : info.topics) {
-                        for (SubscriptionObject subObj : getSubscriptionObjects(topic)) {
+                        Set<SubscriptionObject> subscriptionObjects =
+                                new HashSet<>(getSubscriptionObjects(topic));
+                        for (SubscriptionObject subObj : subscriptionObjects) {
                             if (e instanceof SubscriptionDisconnectedException) {
                                 subObj.onFailure(new ApolloException("Subscription terminated", e));
                                 for (Object c : subObj.getListeners()) {


### PR DESCRIPTION
*Issue #22 : MqttSubscriptionClient: connection lost*

*Description of changes:*
Added creation of `HashSet` with subscription objects just before iteration in `onError()` callback in `subscribe()` method.
As iteration over `getSubscriptionObjects()` result is not synchronized with other methods that can `changesubscriptionsByTopic` field value, modification of topic subscribers while `onError()` callback is in progress can cause `ConcurrentModificationException`. As subscriber (`SubscriptionObject`), for whom `onError()` should trigger `onFailure()` on listeners, already has been added to the set, the simplest way is to create copy of `getSubscriptionObjects()` result and iterate over it.
I tried to use 1.1.0 version of `org.eclipse.paho:org.eclipse.paho.client.mqttv3` with the latest versions of other libraries as suggested in the issue comments, but in this case subscription called `OnCompleted()` right after it had been started and didn't send any successfull responses.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
