### PR TITLE
Changes to make Appsync depend on `AWSCore` version `2.8.0` 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Change Log - AWS AppSync SDK for Android
 
+## [Release 2.6.28](https://github.com/awslabs/aws-mobile-appsync-sdk-android/releases/tag/release_v2.6.28)
+
+### Misc. Updates
+* `AWSAppSync` now depends on `AWSCore` version `2.8.0` instead of `2.7.7`.
+
 ## [Release 2.6.27](https://github.com/awslabs/aws-mobile-appsync-sdk-android/releases/tag/release_v2.6.27)
 
 ### Bug Fixes

--- a/aws-android-sdk-appsync-compiler/src/generated/kotlin/com/apollographql/android/Version.kt
+++ b/aws-android-sdk-appsync-compiler/src/generated/kotlin/com/apollographql/android/Version.kt
@@ -1,3 +1,3 @@
 // Generated file. Do not edit!
 package com.apollographql.android
-val VERSION = "2.6.27"
+val VERSION = "2.6.28"

--- a/gradle.properties
+++ b/gradle.properties
@@ -13,8 +13,8 @@ org.gradle.jvmargs=-Xmx1536m
 org.gradle.parallel=true
 
 GROUP=com.amazonaws
-VERSION_NAME=2.6.27
-AWS_CORE_SDK_VERSION=2.7.7
+VERSION_NAME=2.6.28
+AWS_CORE_SDK_VERSION=2.8.0
 
 POM_URL=https://github.com/awslabs/aws-mobile-appsync-sdk-android
 POM_SCM_URL=https://github.com/awslabs/aws-mobile-appsync-sdk-android


### PR DESCRIPTION
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
