### PR TITLE
Added null check before invoking `onCompleted` in RealAppSyncSubscriptionCall

### DIFF
--- a/aws-android-sdk-appsync-runtime/src/main/java/com/apollographql/apollo/internal/RealAppSyncSubscriptionCall.java
+++ b/aws-android-sdk-appsync-runtime/src/main/java/com/apollographql/apollo/internal/RealAppSyncSubscriptionCall.java
@@ -164,8 +164,10 @@ public class RealAppSyncSubscriptionCall<T> implements AppSyncSubscriptionCall<T
                             try {
                                 subscriptionManager.unsubscribe(subscription);
                                 subscriptionManager.removeListener(subscription, userCallback);
-                                userCallback.onCompleted();
-                                userCallback = null;
+                                if (userCallback != null ) {
+                                    userCallback.onCompleted();
+                                    userCallback = null;
+                                }
                             } finally {
                                 state.set(CANCELED);
                             }


### PR DESCRIPTION

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
