### PR TITLE
Fix inconsistent capitalization in the generated type name

### DIFF
--- a/aws-android-sdk-appsync-compiler/src/main/kotlin/com/apollographql/apollo/compiler/OperationTypeSpecBuilder.kt
+++ b/aws-android-sdk-appsync-compiler/src/main/kotlin/com/apollographql/apollo/compiler/OperationTypeSpecBuilder.kt
@@ -185,7 +185,7 @@ class OperationTypeSpecBuilder(
     return MethodSpec.constructorBuilder()
         .addModifiers(Modifier.PUBLIC)
         .addParameters(operation.variables
-            .map { it.name.decapitalize() to it.type }
+            .map { it.name.decapitalize() to it.type.capitalize() }
             .map { it.first to JavaTypeResolver(context, context.typesPackage).resolve(it.second) }
             .map { ParameterSpec.builder(it.second.unwrapOptionalType(), it.first).build() })
         .addCode(code)
@@ -205,7 +205,7 @@ class OperationTypeSpecBuilder(
       ).let { addType(it.build()) }
     }
     return operation.variables
-        .map { it.name.decapitalize() to it.type }
+        .map { it.name.decapitalize() to it.type.capitalize() }
         .map { it.first to JavaTypeResolver(context, context.typesPackage).resolve(it.second).unwrapOptionalType() }
         .let {
           BuilderTypeSpecBuilder(

--- a/aws-android-sdk-appsync-compiler/src/main/kotlin/com/apollographql/apollo/compiler/VariablesTypeSpecBuilder.kt
+++ b/aws-android-sdk-appsync-compiler/src/main/kotlin/com/apollographql/apollo/compiler/VariablesTypeSpecBuilder.kt
@@ -146,7 +146,7 @@ class VariablesTypeSpecBuilder(
     private val VARIABLES_CLASS_NAME: String = "Variables"
     private val VARIABLES_TYPE_NAME: ClassName = ClassName.get("", VARIABLES_CLASS_NAME)
     private fun Variable.javaTypeName(context: CodeGenerationContext, packageName: String) =
-        JavaTypeResolver(context, packageName).resolve(type).unwrapOptionalType()
+        JavaTypeResolver(context, packageName).resolve(type.capitalize()).unwrapOptionalType()
 
     private val VALUE_MAP_FIELD_NAME = "valueMap"
     private val WRITER_PARAM = ParameterSpec.builder(InputFieldWriter::class.java, "writer").build()

--- a/aws-android-sdk-appsync-tests/src/main/graphql/com/amazonaws/mobileconnectors/appsync/demo/posts.graphql
+++ b/aws-android-sdk-appsync-tests/src/main/graphql/com/amazonaws/mobileconnectors/appsync/demo/posts.graphql
@@ -73,7 +73,7 @@ mutation UpdatePost($input: UpdatePostInput!) {
   }
 }
 
-mutation DeletePost($input: DeletePostInput!) {
+mutation DeletePost($input: deletePostInput!) {
   deletePost(input: $input) {
       id
       title

--- a/aws-android-sdk-appsync-tests/src/main/graphql/com/amazonaws/mobileconnectors/appsync/demo/schema.json
+++ b/aws-android-sdk-appsync-tests/src/main/graphql/com/amazonaws/mobileconnectors/appsync/demo/schema.json
@@ -1488,7 +1488,7 @@
               "name" : null,
               "ofType" : {
                 "kind" : "INPUT_OBJECT",
-                "name" : "DeletePostInput",
+                "name" : "deletePostInput",
                 "ofType" : null
               }
             },
@@ -1809,7 +1809,7 @@
         "possibleTypes" : null
       }, {
         "kind" : "INPUT_OBJECT",
-        "name" : "DeletePostInput",
+        "name" : "deletePostInput",
         "description" : null,
         "fields" : null,
         "inputFields" : [ {


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/awslabs/aws-mobile-appsync-sdk-android/issues/122
*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
