### PR TITLE
Fix inconsistent capitalization of field names

### DIFF
--- a/aws-android-sdk-appsync-compiler/src/main/kotlin/com/apollographql/apollo/compiler/InputTypeSpecBuilder.kt
+++ b/aws-android-sdk-appsync-compiler/src/main/kotlin/com/apollographql/apollo/compiler/InputTypeSpecBuilder.kt
@@ -94,7 +94,7 @@ class InputTypeSpecBuilder(
     val writeCode = fields
         .map {
           InputFieldSpec.build(
-              name = it.name.decapitalize(),
+              name = it.name,
               graphQLType = it.type,
               context = context
           )

--- a/aws-android-sdk-appsync-tests/src/androidTest/java/com/amazonaws/mobileconnectors/appsync/AWSAppSyncQueryInstrumentationTest.java
+++ b/aws-android-sdk-appsync-tests/src/androidTest/java/com/amazonaws/mobileconnectors/appsync/AWSAppSyncQueryInstrumentationTest.java
@@ -649,7 +649,7 @@ public class AWSAppSyncQueryInstrumentationTest {
     public void testCache() {
         AWSAppSyncClient awsAppSyncClient = AppSyncTestSetupHelper.createAppSyncClientWithIAM();
         assertNotNull(awsAppSyncClient);
-        String postID = "bae84e6f-3c65-4c52-a68e-b7d32c6fa8ff";
+        String postID = "89511826-4414-4569-8d5d-075e9f12a923";
 
         queryPost(awsAppSyncClient, AppSyncResponseFetchers.NETWORK_ONLY,postID);
         assertNotNull(getPostQueryResponse);
@@ -669,7 +669,7 @@ public class AWSAppSyncQueryInstrumentationTest {
     public void testCacheWithInputType() {
         AWSAppSyncClient awsAppSyncClient = AppSyncTestSetupHelper.createAppSyncClientWithIAM();
         assertNotNull(awsAppSyncClient);
-        String postID = "bae84e6f-3c65-4c52-a68e-b7d32c6fa8ff";
+        String postID = "89511826-4414-4569-8d5d-075e9f12a923";
         String name = "Home [Scene Six]";
         int version = 0;
 

--- a/aws-android-sdk-appsync-tests/src/main/graphql/com/amazonaws/mobileconnectors/appsync/demo/schema.json
+++ b/aws-android-sdk-appsync-tests/src/main/graphql/com/amazonaws/mobileconnectors/appsync/demo/schema.json
@@ -1813,7 +1813,7 @@
         "description" : null,
         "fields" : null,
         "inputFields" : [ {
-          "name" : "id",
+          "name" : "Id",
           "description" : null,
           "type" : {
             "kind" : "NON_NULL",


### PR DESCRIPTION
*Issue #, if available:*
Fixes : https://github.com/awslabs/aws-mobile-appsync-sdk-android/issues/115

*Description of changes:*
This PR fixes unwanted de-capitalization of the field names starting with an uppercase letter. We currently do not have unit or integration tests for the compiler module. As an interim test for these code changes, I have capitalized first letter of field `Id` for the input type `deletePostInput`. Passing of all the integration tests involving `deletePostInput` validates the correctness  of the fix.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
