### PR TITLE
Validate context and AuthMode in AWSAppSyncClient Builder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Change Log - AWS AppSync SDK for Android
 
-## [Release 2.9.1](https://github.com/awslabs/aws-mobile-appsync-sdk-android/releases/tag/release_v2.9.1)
+## [Release 2.10.0](https://github.com/awslabs/aws-mobile-appsync-sdk-android/releases/tag/release_v2.10.0)
 
 ## Enhancements
 * Add new validations in `AWSAppSyncClient.Builder`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Change Log - AWS AppSync SDK for Android
 
+## [Release 2.9.1](https://github.com/awslabs/aws-mobile-appsync-sdk-android/releases/tag/release_v2.9.1)
+
+## Enhancements
+* Add new validations in `AWSAppSyncClient.Builder`.
+  * Throw `RuntimeException` when Android context passed in is null.
+  * Throw `RuntimException` when there is no valid `AuthMode` object passed in.
+
 ## [Release 2.9.0](https://github.com/awslabs/aws-mobile-appsync-sdk-android/releases/tag/release_v2.9.0)
 
 ## New Features

--- a/aws-android-sdk-appsync-tests/src/androidTest/java/com/amazonaws/mobileconnectors/appsync/AWSAppSyncMultiClientInstrumentationTest.java
+++ b/aws-android-sdk-appsync-tests/src/androidTest/java/com/amazonaws/mobileconnectors/appsync/AWSAppSyncMultiClientInstrumentationTest.java
@@ -1587,4 +1587,81 @@ public class AWSAppSyncMultiClientInstrumentationTest {
         assertNotNull(resultMap.get("API_KEY"));
         assertTrue(resultMap.get("AWS_IAM") > resultMap.get("API_KEY"));
     }
+
+    @Test
+    public void testNoContextThrowsException() {
+        AWSConfiguration awsConfiguration = new AWSConfiguration(InstrumentationRegistry.getTargetContext());
+
+        String apiKey = null;
+        String serverUrl  = null;
+        Regions region = null;
+        String clientDatabasePrefix = null;
+
+        try {
+            apiKey = awsConfiguration.optJsonObject("AppSync").getString("ApiKey");
+            serverUrl = awsConfiguration.optJsonObject("AppSync").getString("ApiUrl");
+            region = Regions.fromName(awsConfiguration.optJsonObject("AppSync").getString("Region"));
+            clientDatabasePrefix = awsConfiguration.optJsonObject("AppSync").getString("ClientDatabasePrefix");
+        } catch (JSONException e) {
+            fail("Error in reading from awsconfiguration.json. " + e.getLocalizedMessage());
+        }
+
+        try {
+            AWSAppSyncClient.builder()
+                    .apiKey(new BasicAPIKeyAuthProvider(apiKey))
+                    .serverUrl(serverUrl)
+                    .region(region)
+                    .useClientDatabasePrefix(true)
+                    .clientDatabasePrefix(clientDatabasePrefix)
+                    .build();
+        } catch (Exception ex) {
+            assertTrue(ex.getLocalizedMessage().startsWith("A valid Android Context is required."));
+        }
+    }
+
+    @Test
+    public void testNoAuthModeObjectThrowsExceptionViaCode() {
+        AWSConfiguration awsConfiguration = new AWSConfiguration(InstrumentationRegistry.getTargetContext());
+
+        String apiKey = null;
+        String serverUrl  = null;
+        Regions region = null;
+        String clientDatabasePrefix = null;
+
+        try {
+            apiKey = awsConfiguration.optJsonObject("AppSync").getString("ApiKey");
+            serverUrl = awsConfiguration.optJsonObject("AppSync").getString("ApiUrl");
+            region = Regions.fromName(awsConfiguration.optJsonObject("AppSync").getString("Region"));
+            clientDatabasePrefix = awsConfiguration.optJsonObject("AppSync").getString("ClientDatabasePrefix");
+        } catch (JSONException e) {
+            fail("Error in reading from awsconfiguration.json. " + e.getLocalizedMessage());
+        }
+
+        try {
+            AWSAppSyncClient.builder()
+                    .context(InstrumentationRegistry.getTargetContext())
+                    .serverUrl(serverUrl)
+                    .region(region)
+                    .useClientDatabasePrefix(true)
+                    .clientDatabasePrefix(clientDatabasePrefix)
+                    .build();
+        } catch (Exception ex) {
+            assertTrue(ex.getLocalizedMessage().startsWith("No valid AuthMode object is passed in to the builder."));
+        }
+    }
+
+    @Test
+    public void testNoAuthModeObjectThrowsExceptionViaAWSConfiguration() {
+        AWSConfiguration awsConfiguration = new AWSConfiguration(InstrumentationRegistry.getTargetContext());
+
+        try {
+            AWSAppSyncClient.builder()
+                    .context(InstrumentationRegistry.getTargetContext())
+                    .awsConfiguration(awsConfiguration)
+                    .useClientDatabasePrefix(true)
+                    .build();
+        } catch (Exception ex) {
+            assertTrue(ex.getLocalizedMessage().startsWith("No valid AuthMode object is passed in to the builder."));
+        }
+    }
 }

--- a/aws-android-sdk-appsync/src/main/java/com/amazonaws/mobileconnectors/appsync/AWSAppSyncClient.java
+++ b/aws-android-sdk-appsync/src/main/java/com/amazonaws/mobileconnectors/appsync/AWSAppSyncClient.java
@@ -360,7 +360,7 @@ public class AWSAppSyncClient {
             return this;
         }
 
-        public Builder context(Context context) {
+        public Builder context(@Nonnull Context context) {
             mContext = context;
             return this;
         }
@@ -504,6 +504,11 @@ public class AWSAppSyncClient {
          * @return AWSAppSyncClient object built from AWSAppSyncClient.Builder
          */
         public AWSAppSyncClient build() {
+            // Validate context
+            if (mContext == null) {
+                throw new RuntimeException("A valid Android Context is required.");
+            }
+
             // Validate AuthMode
             Map<Object, AuthMode> authModeObjects = new HashMap<>();
             authModeObjects.put(mApiKey, AuthMode.API_KEY);
@@ -564,6 +569,7 @@ public class AWSAppSyncClient {
                     final AuthMode authMode = authModeFromConfigJson;
                     if (selectedAuthModeObject == null && authMode.equals(AuthMode.API_KEY)) {
                         mApiKey = new BasicAPIKeyAuthProvider(appSyncJsonObject.getString("ApiKey"));
+                        authModeObjects.put(mApiKey, AuthMode.API_KEY);
                         selectedAuthMode = authMode;
                     }
 
@@ -576,6 +582,11 @@ public class AWSAppSyncClient {
                     throw new RuntimeException("Please check the AppSync configuration in " +
                             "awsconfiguration.json.", exception);
                 }
+            }
+
+            // Validate for the presence of one AuthMode object
+            if (authModeObjects.size() == 0) {
+                throw new RuntimeException("No valid AuthMode object is passed in to the builder.");
             }
 
             if (mUseClientDatabasePrefix && (mClientDatabasePrefix == null || StringUtils.isBlank(mClientDatabasePrefix))) {


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

* Throw a RuntimeException when context is not passed in or is null.
* Throw a RuntimeException when there is no Auth object passed in.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
