### PR TITLE
Respect the user-specified customTypeMapping for types in generated code

### DIFF
--- a/aws-android-sdk-appsync-compiler/src/main/kotlin/com/apollographql/apollo/compiler/GraphQLCompiler.kt
+++ b/aws-android-sdk-appsync-compiler/src/main/kotlin/com/apollographql/apollo/compiler/GraphQLCompiler.kt
@@ -78,15 +78,7 @@ class GraphQLCompiler {
     return typeDeclarations.filter { it.kind == TypeDeclaration.KIND_SCALAR_TYPE }
         .associate { it.name to (this[it.name] ?: ClassNames.OBJECT.toString()) }
         .plus(idScalarTypeMap)
-        .plus("AWSDate" to ClassNames.STRING.toString())
-        .plus("AWSTime" to ClassNames.STRING.toString())
-        .plus("AWSDateTime" to ClassNames.STRING.toString())
         .plus("AWSTimestamp" to TypeName.LONG.box().toString())
-        .plus("AWSEmail" to ClassNames.STRING.toString())
-        .plus("AWSJSON" to ClassNames.STRING.toString())
-        .plus("AWSURL" to ClassNames.STRING.toString())
-        .plus("AWSPhone" to ClassNames.STRING.toString())
-        .plus("AWSIPAddress" to ClassNames.STRING.toString())
   }
 
   companion object {


### PR DESCRIPTION
*Issue #, if available:*
Fixes https://github.com/awslabs/aws-mobile-appsync-sdk-android/issues/77 and https://github.com/awslabs/aws-mobile-appsync-sdk-android/issues/127. 
*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
