### PR TITLE
Changes GraphQLStoreOperation.Callback visibility to public

### DIFF
--- a/aws-android-sdk-appsync-runtime/src/main/java/com/apollographql/apollo/cache/normalized/GraphQLStoreOperation.java
+++ b/aws-android-sdk-appsync-runtime/src/main/java/com/apollographql/apollo/cache/normalized/GraphQLStoreOperation.java
@@ -118,7 +118,7 @@ public abstract class GraphQLStoreOperation<T> {
    *
    * @param <T> result type
    */
-  interface Callback<T> {
+  public interface Callback<T> {
 
     void onSuccess(T result);
 


### PR DESCRIPTION
Implements #192 

Changes the interface GraphQLStoreOperation.Callback visibility to public

This change has already been made in the apollo-android repository.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
