### PR TITLE
Objects with non-existing field cannot be partially read

### DIFF
--- a/aws-android-sdk-appsync-runtime/src/main/java/com/apollographql/apollo/internal/field/CacheFieldValueResolver.java
+++ b/aws-android-sdk-appsync-runtime/src/main/java/com/apollographql/apollo/internal/field/CacheFieldValueResolver.java
@@ -110,7 +110,7 @@ public final class CacheFieldValueResolver implements FieldValueResolver<Record>
   @SuppressWarnings("unchecked") private <T> T fieldValue(Record record, ResponseField field) {
     String fieldKey = field.cacheKey(variables);
     if (!record.hasField(fieldKey)) {
-      throw new NullPointerException("Missing value: " + field.fieldName());
+      return null;
     }
     return (T) record.field(fieldKey);
   }


### PR DESCRIPTION
*Issue #, if available:* https://github.com/awslabs/aws-mobile-appsync-sdk-android/issues/116

*Description of changes:*
fieldValue returns null if the fieldKey is not found instead of throwing a NullPointerException. This will solve the issue and allow AppSync to read the stored object even if one of its fields is missing.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
