### PR TITLE
Update most all dependencies to latest versions

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -28,13 +28,13 @@ android {
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
-    implementation 'com.android.support:appcompat-v7:28.+'
-    implementation 'com.android.support:support-compat:28.+'
-    implementation 'com.android.support:recyclerview-v7:28.+'
-    implementation 'com.android.support:design:28.+'
+    implementation 'com.android.support:appcompat-v7:28.0.0'
+    implementation 'com.android.support:support-compat:28.0.0'
+    implementation 'com.android.support:recyclerview-v7:28.0.0'
+    implementation 'com.android.support:design:28.0.0'
 
-    
-    implementation 'com.android.support.constraint:constraint-layout:1.1.2'
+
+    implementation 'com.android.support.constraint:constraint-layout:1.1.3'
     testImplementation 'junit:junit:4.12'
     androidTestImplementation 'com.android.support.test:runner:1.0.2'
     androidTestImplementation 'com.android.support.test.espresso:espresso-core:3.0.2'

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -35,7 +35,7 @@ dependencies {
 
 
     implementation 'com.android.support.constraint:constraint-layout:1.1.3'
-    testImplementation 'junit:junit:4.12'
+    testImplementation 'junit:junit:4.13'
     androidTestImplementation 'com.android.support.test:runner:1.0.2'
     androidTestImplementation 'com.android.support.test.espresso:espresso-core:3.0.2'
 

--- a/aws-android-sdk-appsync-api/build.gradle
+++ b/aws-android-sdk-appsync-api/build.gradle
@@ -8,7 +8,7 @@ dependencies {
     implementation 'com.google.code.findbugs:jsr305:3.0.1' // compileOnly
     api 'javax.annotation:jsr250-api:1.0' // compileOnly
 
-    implementation "com.squareup.okhttp3:okhttp:3.8.1" // compileOnly
+    implementation 'com.squareup.okhttp3:okhttp:4.3.1' // compileOnly
 }
 
 publishing {

--- a/aws-android-sdk-appsync-api/build.gradle
+++ b/aws-android-sdk-appsync-api/build.gradle
@@ -5,7 +5,7 @@ apply from: rootProject.file('gradle-mvn-push.gradle')
 
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
-    implementation 'com.google.code.findbugs:jsr305:3.0.1' // compileOnly
+    implementation 'com.google.code.findbugs:jsr305:3.0.2' // compileOnly
     api 'javax.annotation:jsr250-api:1.0' // compileOnly
 
     implementation 'com.squareup.okhttp3:okhttp:4.3.1' // compileOnly

--- a/aws-android-sdk-appsync-compiler/build.gradle
+++ b/aws-android-sdk-appsync-compiler/build.gradle
@@ -15,7 +15,7 @@ dependencies {
     implementation 'com.squareup:javapoet:1.8.0' // impl
     implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version" // impl
     implementation 'com.squareup.moshi:moshi:1.5.0' // impl
-    implementation 'com.google.code.findbugs:jsr305:3.0.1' // compileOnly
+    implementation 'com.google.code.findbugs:jsr305:3.0.2' // compileOnly
 
     implementation project(':aws-android-sdk-appsync-api') // impl
 }

--- a/aws-android-sdk-appsync-gradle-plugin/build.gradle
+++ b/aws-android-sdk-appsync-gradle-plugin/build.gradle
@@ -14,7 +14,7 @@ dependencies {
     compileOnly gradleApi()
     compileOnly localGroovy()
     implementation "com.moowork.gradle:gradle-node-plugin:1.0.0" // compileOnly
-    implementation 'com.android.tools.build:gradle:3.2.1' // compileOnly
+    implementation 'com.android.tools.build:gradle:3.5.3' // compileOnly
     implementation 'com.squareup.moshi:moshi:1.5.0' // impl
 
     implementation project(':aws-android-sdk-appsync-compiler') // impl

--- a/aws-android-sdk-appsync-runtime/build.gradle
+++ b/aws-android-sdk-appsync-runtime/build.gradle
@@ -6,7 +6,7 @@ apply from: rootProject.file('gradle-mvn-push.gradle')
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
 
-    compileOnly 'com.google.code.findbugs:jsr305:3.0.1'
+    compileOnly 'com.google.code.findbugs:jsr305:3.0.2'
     implementation 'com.squareup.okhttp3:okhttp:4.3.1' // impl
     api "com.nytimes.android:cache:2.0.2" // impl
 

--- a/aws-android-sdk-appsync-runtime/build.gradle
+++ b/aws-android-sdk-appsync-runtime/build.gradle
@@ -1,6 +1,5 @@
 apply plugin: 'java-library'
 apply plugin: 'maven-publish'
-
 apply from: rootProject.file('gradle-mvn-push.gradle')
 
 dependencies {
@@ -8,7 +7,7 @@ dependencies {
 
     compileOnly 'com.google.code.findbugs:jsr305:3.0.2'
     implementation 'com.squareup.okhttp3:okhttp:4.3.1' // impl
-    api "com.nytimes.android:cache:2.0.2" // impl
+    api 'com.nytimes.android:cache:2.1.1' // impl
 
     api project(':aws-android-sdk-appsync-api') // api
 }
@@ -26,3 +25,4 @@ publishing {
 
 sourceCompatibility = "1.7"
 targetCompatibility = "1.7"
+

--- a/aws-android-sdk-appsync-runtime/build.gradle
+++ b/aws-android-sdk-appsync-runtime/build.gradle
@@ -7,7 +7,7 @@ dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
 
     compileOnly 'com.google.code.findbugs:jsr305:3.0.1'
-    implementation "com.squareup.okhttp3:okhttp:3.8.1" // impl
+    implementation 'com.squareup.okhttp3:okhttp:4.3.1' // impl
     api "com.nytimes.android:cache:2.0.2" // impl
 
     api project(':aws-android-sdk-appsync-api') // api

--- a/aws-android-sdk-appsync-runtime/src/main/java/com/apollographql/apollo/internal/interceptor/ApolloParseInterceptor.java
+++ b/aws-android-sdk-appsync-runtime/src/main/java/com/apollographql/apollo/internal/interceptor/ApolloParseInterceptor.java
@@ -7,9 +7,6 @@
 
 package com.apollographql.apollo.internal.interceptor;
 
-import com.apollographql.apollo.api.Subscription;
-import com.apollographql.apollo.interceptor.ApolloInterceptor;
-import com.apollographql.apollo.interceptor.ApolloInterceptorChain;
 import com.apollographql.apollo.api.Operation;
 import com.apollographql.apollo.api.Response;
 import com.apollographql.apollo.api.ResponseFieldMapper;
@@ -17,10 +14,12 @@ import com.apollographql.apollo.api.cache.http.HttpCache;
 import com.apollographql.apollo.exception.ApolloException;
 import com.apollographql.apollo.exception.ApolloHttpException;
 import com.apollographql.apollo.exception.ApolloParseException;
+import com.apollographql.apollo.interceptor.ApolloInterceptor;
+import com.apollographql.apollo.interceptor.ApolloInterceptorChain;
+import com.apollographql.apollo.internal.ApolloLogger;
 import com.apollographql.apollo.internal.cache.normalized.ResponseNormalizer;
 import com.apollographql.apollo.internal.response.OperationResponseParser;
 import com.apollographql.apollo.internal.response.ScalarTypeAdapters;
-import com.apollographql.apollo.internal.ApolloLogger;
 
 import java.io.Closeable;
 import java.io.IOException;
@@ -33,8 +32,6 @@ import javax.annotation.Nonnull;
 import okhttp3.ResponseBody;
 import okio.Buffer;
 import okio.BufferedSource;
-
-import static okhttp3.internal.Util.UTF_8;
 
 /**
  * ApolloParseInterceptor is a concrete {@link ApolloInterceptor} responsible for inflating the http responses into

--- a/aws-android-sdk-appsync/build.gradle
+++ b/aws-android-sdk-appsync/build.gradle
@@ -44,19 +44,20 @@ dependencies {
 
     compileOnly project(':aws-android-sdk-appsync-runtime')
 
-    testImplementation 'junit:junit:4.12'
-    androidTestImplementation 'junit:junit:4.12'
+    androidTestImplementation 'junit:junit:4.13'
     androidTestImplementation 'com.android.support.test:runner:1.0.2'
     androidTestImplementation 'com.android.support.test.espresso:espresso-core:3.0.2'
-
     androidTestImplementation project(':aws-android-sdk-appsync-runtime')
     androidTestImplementation project(':aws-android-sdk-appsync-api')
 
     androidTestImplementation "com.amazonaws:aws-android-sdk-cognitoidentityprovider:$aws_version"
-    androidTestImplementation "org.mockito:mockito-core:2.19.1"
     androidTestImplementation project(':aws-android-sdk-appsync-runtime')
-    testImplementation "org.robolectric:robolectric:3.8"
-    testImplementation "org.mockito:mockito-core:2.19.1"
+    testImplementation 'junit:junit:4.13'
+    testImplementation ('org.robolectric:robolectric:4.3.1') {
+        // https://github.com/robolectric/robolectric/issues/5245
+        exclude group: 'com.google.auto.service', module: 'auto-service'
+    }
+    testImplementation 'org.mockito:mockito-core:3.2.4'
     testImplementation "com.amazonaws:aws-android-sdk-cognitoidentityprovider:$aws_version"
     testImplementation project(':aws-android-sdk-appsync-runtime')
     implementation ("com.amazonaws:aws-android-sdk-mobile-client:$aws_version@aar") { transitive = true }

--- a/aws-android-sdk-appsync/build.gradle
+++ b/aws-android-sdk-appsync/build.gradle
@@ -33,7 +33,7 @@ dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
 
     implementation 'com.google.code.findbugs:jsr305:3.0.1' // api
-    implementation "com.squareup.okhttp3:okhttp:3.8.1" // impl
+    implementation 'com.squareup.okhttp3:okhttp:4.3.1' // impl
 
     implementation "com.amazonaws:aws-android-sdk-core:$aws_version" // api
     compileOnly "com.amazonaws:aws-android-sdk-cognitoidentityprovider:$aws_version"

--- a/aws-android-sdk-appsync/build.gradle
+++ b/aws-android-sdk-appsync/build.gradle
@@ -32,7 +32,7 @@ dependencies {
 
     implementation fileTree(dir: 'libs', include: ['*.jar'])
 
-    implementation 'com.google.code.findbugs:jsr305:3.0.1' // api
+    implementation 'com.google.code.findbugs:jsr305:3.0.2' // api
     implementation 'com.squareup.okhttp3:okhttp:4.3.1' // impl
 
     implementation "com.amazonaws:aws-android-sdk-core:$aws_version" // api

--- a/aws-android-sdk-appsync/src/test/java/com/amazonaws/mobileconnectors/appsync/AppSyncClientUnitTest.java
+++ b/aws-android-sdk-appsync/src/test/java/com/amazonaws/mobileconnectors/appsync/AppSyncClientUnitTest.java
@@ -25,6 +25,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mockito;
 import org.robolectric.RobolectricTestRunner;
+import org.robolectric.RuntimeEnvironment;
 import org.robolectric.annotation.Config;
 import org.robolectric.shadows.ShadowApplication;
 
@@ -64,7 +65,7 @@ public class AppSyncClientUnitTest {
 
     @Before
     public void setup() {
-        shadowContext = ShadowApplication.getInstance().getApplicationContext();
+        shadowContext = RuntimeEnvironment.application;
         mockContext = Mockito.mock(Context.class);
         mockLogger = Mockito.mock(ApolloLogger.class);
         mockSubscription = Mockito.mock(Subscription.class);

--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ buildscript {
     dependencies {
         classpath 'com.android.tools.build:gradle:3.5.3'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
-        classpath 'com.amazonaws:aws-android-sdk-appsync-gradle-plugin:2.8.+'
+        classpath 'com.amazonaws:aws-android-sdk-appsync-gradle-plugin:2.8.3'
     }
 }
 

--- a/gradle-mvn-push.gradle
+++ b/gradle-mvn-push.gradle
@@ -151,6 +151,11 @@ afterEvaluate { project ->
 
     task androidJavadocs(type: Javadoc) {
       source = android.sourceSets.main.java.source
+      android.libraryVariants.all { variant ->
+        if (variant.name == 'release') {
+          owner.classpath += variant.javaCompiler.classpath
+        }
+      }
       classpath += project.files(android.getBootClasspath().join(File.pathSeparator))
     }
 


### PR DESCRIPTION
Moshi and JavaPoet are held back at earlier versions for now, as their upgrades involve non-trivial changes.

```
Android Support Libraries -> 28.0.0
Android Constraint Layout -> 1.1.3
jUnit -> 4.13
Robolectric -> 4.3.1
Mockito -> 3.2.4
Findbugs JSR305 -> 3.0.2
OkHttp3 -> 4.3.1
Android Gradle Plugin -> 3.5.3
NYTimes Cache -> 2.1.1
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.