### PR TITLE
Update subscription response content-type

### DIFF
--- a/aws-android-sdk-appsync/src/main/java/com/amazonaws/mobileconnectors/appsync/ApolloResponseBuilder.java
+++ b/aws-android-sdk-appsync/src/main/java/com/amazonaws/mobileconnectors/appsync/ApolloResponseBuilder.java
@@ -29,6 +29,9 @@ import okhttp3.ResponseBody;
  */
 class ApolloResponseBuilder {
     private static final String TAG = ApolloResponseBuilder.class.getSimpleName();
+    private static final String CONTENT_TYPE = "application/json";
+    private static final MediaType MEDIA_TYPE = MediaType.parse(CONTENT_TYPE);
+
     private final Map<ScalarType, CustomTypeAdapter> customTypeAdapters;
     private final ResponseNormalizer<Map<String, Object>> mapResponseNormalizer;
 
@@ -41,7 +44,7 @@ class ApolloResponseBuilder {
 
     <D extends Operation.Data, T, V extends Operation.Variables> Response<T> buildResponse(String message, Subscription<D, T, V> subscription) {
         // Parse the response using OperationResponseParser
-        ResponseBody messageBody = ResponseBody.create(MediaType.parse("text/plain"), message);
+        ResponseBody messageBody = ResponseBody.create(message, MEDIA_TYPE);
         OperationResponseParser<D, T> parser = new OperationResponseParser<>(
             subscription,
             subscription.responseFieldMapper(),

--- a/aws-android-sdk-appsync/src/main/java/com/amazonaws/mobileconnectors/appsync/subscription/SubscriptionObject.java
+++ b/aws-android-sdk-appsync/src/main/java/com/amazonaws/mobileconnectors/appsync/subscription/SubscriptionObject.java
@@ -27,7 +27,9 @@ import okhttp3.MediaType;
 import okhttp3.ResponseBody;
 
 public class SubscriptionObject<D extends Operation.Data, T, V extends Operation.Variables> {
-    private final static String TAG = SubscriptionObject.class.getSimpleName();
+    private static final String TAG = SubscriptionObject.class.getSimpleName();
+    private static final String CONTENT_TYPE = "application/json";
+    private static final MediaType MEDIA_TYPE = MediaType.parse(CONTENT_TYPE);
 
     public Subscription<D, T, V> subscription;
     public Set<String> topics;
@@ -71,9 +73,12 @@ public class SubscriptionObject<D extends Operation.Data, T, V extends Operation
     public void onMessage(final String msg) {
         try {
             //TODO: Check why is this being converted to a Response Body
-            ResponseBody messageBody = ResponseBody.create(MediaType.parse("text/plain"), msg);
-            OperationResponseParser<D, T> parser = new OperationResponseParser(subscription,
-                    subscription.responseFieldMapper(), scalarTypeAdapters, normalizer);
+            ResponseBody messageBody = ResponseBody.create(msg, MEDIA_TYPE);
+            OperationResponseParser<D, T> parser = new OperationResponseParser<>(
+                    subscription,
+                    subscription.responseFieldMapper(),
+                    scalarTypeAdapters,
+                    normalizer);
             Response<T> parsedResponse = parser.parse(messageBody.source());
 
             if (parsedResponse.hasErrors()) {


### PR DESCRIPTION
*Issue #, if available:*
https://t.corp.amazon.com/mobilesdk-4697 (internal ticket)

*Description of changes:*
Use `"application/json"` as content-type to parse subscription responses to. This resolves the inconsistency in json response between subscription (previously parsed to `"text/plain"`) and query/mutation (parsed to `"application/json"`).


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
