### PR TITLE
Introduce a bit of code organization for the tests

### DIFF
--- a/aws-android-sdk-appsync-tests/src/androidTest/java/com/amazonaws/mobileconnectors/appsync/SyncStore.java
+++ b/aws-android-sdk-appsync-tests/src/androidTest/java/com/amazonaws/mobileconnectors/appsync/SyncStore.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2019-2019 Amazon.com,
+ * Inc. or its affiliates. All Rights Reserved.
+ * <p>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.amazonaws.mobileconnectors.appsync;
+
+import static com.amazonaws.mobileconnectors.appsync.AWSAppSyncClient.DATABASE_NAME_DELIMITER;
+import static com.amazonaws.mobileconnectors.appsync.AWSAppSyncClient.DEFAULT_DELTA_SYNC_SQL_STORE_NAME;
+import static com.amazonaws.mobileconnectors.appsync.AWSAppSyncClient.DEFAULT_MUTATION_SQL_STORE_NAME;
+import static com.amazonaws.mobileconnectors.appsync.AWSAppSyncClient.DEFAULT_QUERY_SQL_STORE_NAME;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+/**
+ * This utility must live in the same package as {@link AWSAppSyncClient},
+ * since it accesses package-visibility fields on the {@link AWSAppSyncClient}.
+ */
+public final class SyncStore {
+    private SyncStore() {}
+
+    public static void validate(AWSAppSyncClient client, String clientDatabasePrefix) {
+        assertNotNull(client.mSyncStore);
+        if (clientDatabasePrefix != null) {
+            assertEquals(
+                clientDatabasePrefix + DATABASE_NAME_DELIMITER + DEFAULT_QUERY_SQL_STORE_NAME,
+                client.querySqlStoreName
+            );
+            assertEquals(
+                clientDatabasePrefix + DATABASE_NAME_DELIMITER + DEFAULT_MUTATION_SQL_STORE_NAME,
+                client.mutationSqlStoreName
+            );
+            assertEquals(
+                clientDatabasePrefix + DATABASE_NAME_DELIMITER + DEFAULT_DELTA_SYNC_SQL_STORE_NAME,
+                client.deltaSyncSqlStoreName
+            );
+        } else {
+            assertEquals(DEFAULT_QUERY_SQL_STORE_NAME, client.querySqlStoreName);
+            assertEquals(DEFAULT_MUTATION_SQL_STORE_NAME, client.mutationSqlStoreName);
+            assertEquals(DEFAULT_DELTA_SYNC_SQL_STORE_NAME, client.deltaSyncSqlStoreName);
+        }
+    }
+}

--- a/aws-android-sdk-appsync-tests/src/androidTest/java/com/amazonaws/mobileconnectors/appsync/client/AWSAppSyncClients.java
+++ b/aws-android-sdk-appsync-tests/src/androidTest/java/com/amazonaws/mobileconnectors/appsync/client/AWSAppSyncClients.java
@@ -5,12 +5,18 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-package com.amazonaws.mobileconnectors.appsync;
+package com.amazonaws.mobileconnectors.appsync.client;
 
 import android.support.annotation.NonNull;
 import android.util.Log;
 
 import com.amazonaws.mobile.config.AWSConfiguration;
+import com.amazonaws.mobileconnectors.appsync.AWSAppSyncClient;
+import com.amazonaws.mobileconnectors.appsync.S3ObjectManagerImplementation;
+import com.amazonaws.mobileconnectors.appsync.SyncStore;
+import com.amazonaws.mobileconnectors.appsync.identity.DelayedCognitoCredentialsProvider;
+import com.amazonaws.mobileconnectors.appsync.identity.TestAWSMobileClient;
+import com.amazonaws.mobileconnectors.appsync.util.JsonExtract;
 import com.amazonaws.regions.Region;
 import com.amazonaws.regions.Regions;
 import com.amazonaws.services.s3.AmazonS3Client;
@@ -23,18 +29,16 @@ import org.json.JSONObject;
 import java.util.concurrent.TimeUnit;
 
 import static android.support.test.InstrumentationRegistry.getTargetContext;
-import static com.amazonaws.mobileconnectors.appsync.AWSAppSyncClient.DATABASE_NAME_DELIMITER;
-import static com.amazonaws.mobileconnectors.appsync.AWSAppSyncClient.DEFAULT_DELTA_SYNC_SQL_STORE_NAME;
-import static com.amazonaws.mobileconnectors.appsync.AWSAppSyncClient.DEFAULT_MUTATION_SQL_STORE_NAME;
-import static com.amazonaws.mobileconnectors.appsync.AWSAppSyncClient.DEFAULT_QUERY_SQL_STORE_NAME;
-import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 
-final class AWSAppSyncClients {
+/**
+ * This is factory class to create various {@link AWSAppSyncClient}s.
+ */
+public final class AWSAppSyncClients {
     private static final String TAG = AWSAppSyncClients.class.getName();
 
     @NonNull
-    static AWSAppSyncClient withApiKeyForGogiTest() {
+    public static AWSAppSyncClient withApiKeyForGogiTest() {
         AWSConfiguration awsConfiguration = new AWSConfiguration(getTargetContext());
         awsConfiguration.setConfiguration("SubscriptionIntegrationTestGogi");
         return AWSAppSyncClient.builder()
@@ -44,12 +48,12 @@ final class AWSAppSyncClients {
     }
 
     @NonNull
-    static AWSAppSyncClient withIAMFromAWSConfiguration() {
+    public static AWSAppSyncClient withIAMFromAWSConfiguration() {
         return withIAMFromAWSConfiguration(true, 0);
     }
 
     @NonNull
-    static AWSAppSyncClient withIAMFromAWSConfiguration(boolean subscriptionsAutoReconnect, long credentialsDelay) {
+    public static AWSAppSyncClient withIAMFromAWSConfiguration(boolean subscriptionsAutoReconnect, long credentialsDelay) {
         AWSConfiguration awsConfiguration = new AWSConfiguration(getTargetContext());
         awsConfiguration.setConfiguration("MultiAuthAndroidIntegTestApp_AWS_IAM");
 
@@ -81,12 +85,12 @@ final class AWSAppSyncClients {
     }
 
     @NonNull
-    static AWSAppSyncClient withAPIKEYFromAWSConfiguration() {
+    public static AWSAppSyncClient withAPIKEYFromAWSConfiguration() {
         return withAPIKEYFromAWSConfiguration(true, 0);
     }
 
     @NonNull
-    static AWSAppSyncClient withAPIKEYFromAWSConfiguration(boolean subscriptionsAutoReconnect, long credentialsDelay) {
+    public static AWSAppSyncClient withAPIKEYFromAWSConfiguration(boolean subscriptionsAutoReconnect, long credentialsDelay) {
         AWSConfiguration awsConfiguration = new AWSConfiguration(getTargetContext());
 
         JSONObject ccpConfig = awsConfiguration.optJsonObject("CredentialsProvider");
@@ -116,7 +120,7 @@ final class AWSAppSyncClients {
     }
 
     @NonNull
-    static AWSAppSyncClient withUserPoolsFromAWSConfiguration() {
+    public static AWSAppSyncClient withUserPoolsFromAWSConfiguration() {
         AWSConfiguration awsConfiguration = new AWSConfiguration(getTargetContext());
         awsConfiguration.setConfiguration("MultiAuthAndroidIntegTestApp_AMAZON_COGNITO_USER_POOLS");
 
@@ -141,8 +145,8 @@ final class AWSAppSyncClients {
     }
 
     @NonNull
-    static AWSAppSyncClient withUserPools2FromAWSConfiguration(
-            String idTokenStringForCustomCognitoUserPool) {
+    public static AWSAppSyncClient withUserPools2FromAWSConfiguration(
+        String idTokenStringForCustomCognitoUserPool) {
         // Amazon Cognito User Pools - Custom CognitoUserPool
         AWSConfiguration awsConfiguration = new AWSConfiguration(getTargetContext());
         awsConfiguration.setConfiguration("MultiAuthAndroidIntegTestApp_AMAZON_COGNITO_USER_POOLS_2");
@@ -162,32 +166,14 @@ final class AWSAppSyncClients {
         return awsAppSyncClient4;
     }
 
-    static void validateAppSyncClient(
+    public static void validateAppSyncClient(
             AWSAppSyncClient awsAppSyncClient, String clientDatabasePrefix, @SuppressWarnings("unused") String clientName) {
         assertNotNull(awsAppSyncClient);
-        assertNotNull(awsAppSyncClient.mSyncStore);
-        if (clientDatabasePrefix != null) {
-            assertEquals(
-                clientDatabasePrefix + DATABASE_NAME_DELIMITER + DEFAULT_QUERY_SQL_STORE_NAME,
-                awsAppSyncClient.querySqlStoreName
-            );
-            assertEquals(
-                clientDatabasePrefix + DATABASE_NAME_DELIMITER + DEFAULT_MUTATION_SQL_STORE_NAME,
-                awsAppSyncClient.mutationSqlStoreName
-            );
-            assertEquals(
-                clientDatabasePrefix + DATABASE_NAME_DELIMITER + DEFAULT_DELTA_SYNC_SQL_STORE_NAME,
-                awsAppSyncClient.deltaSyncSqlStoreName
-            );
-        } else {
-            assertEquals(DEFAULT_QUERY_SQL_STORE_NAME, awsAppSyncClient.querySqlStoreName);
-            assertEquals(DEFAULT_MUTATION_SQL_STORE_NAME, awsAppSyncClient.mutationSqlStoreName);
-            assertEquals(DEFAULT_DELTA_SYNC_SQL_STORE_NAME, awsAppSyncClient.deltaSyncSqlStoreName);
-        }
+        SyncStore.validate(awsAppSyncClient, clientDatabasePrefix);
     }
 
     @NonNull
-    static AWSAppSyncClient withUserPoolsFromAWSConfiguration(ResponseFetcher responseFetcher) {
+    public static AWSAppSyncClient withUserPoolsFromAWSConfiguration(ResponseFetcher responseFetcher) {
         // Amazon Cognito User Pools
         AWSConfiguration awsConfiguration = new AWSConfiguration(getTargetContext());
         awsConfiguration.setConfiguration("MultiAuthAndroidIntegTestApp_AMAZON_COGNITO_USER_POOLS");
@@ -214,8 +200,8 @@ final class AWSAppSyncClients {
     }
 
     @NonNull
-    static AWSAppSyncClient withUserPools2FromAWSConfiguration(
-            String idTokenStringForCustomCognitoUserPool, ResponseFetcher responseFetcher) {
+    public static AWSAppSyncClient withUserPools2FromAWSConfiguration(
+        String idTokenStringForCustomCognitoUserPool, ResponseFetcher responseFetcher) {
         // Amazon Cognito User Pools - Custom CognitoUserPool
         String clientDatabasePrefix = null;
         String clientName = null;

--- a/aws-android-sdk-appsync-tests/src/androidTest/java/com/amazonaws/mobileconnectors/appsync/client/DelegatingGraphQLCallback.java
+++ b/aws-android-sdk-appsync-tests/src/androidTest/java/com/amazonaws/mobileconnectors/appsync/client/DelegatingGraphQLCallback.java
@@ -5,10 +5,11 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-package com.amazonaws.mobileconnectors.appsync;
+package com.amazonaws.mobileconnectors.appsync.client;
 
 import android.support.annotation.NonNull;
 
+import com.amazonaws.mobileconnectors.appsync.util.Consumer;
 import com.apollographql.apollo.GraphQLCall;
 import com.apollographql.apollo.api.Response;
 import com.apollographql.apollo.exception.ApolloException;
@@ -19,7 +20,7 @@ import com.apollographql.apollo.exception.ApolloException;
  * {@link Response}, it just passes it to the corresponding {@link Consumer} by calling
  * {@link Consumer#accept(T)}.
  */
-final class DelegatingGraphQLCallback<T> extends GraphQLCall.Callback<T> {
+public final class DelegatingGraphQLCallback<T> extends GraphQLCall.Callback<T> {
     private final Consumer<Response<T>> onResponse;
     private final Consumer<ApolloException> onFailure;
 
@@ -38,9 +39,9 @@ final class DelegatingGraphQLCallback<T> extends GraphQLCall.Callback<T> {
      * @param <T> Type of data in response
      * @return A delegating GraphQLCall.Callback
      */
-    static <T> DelegatingGraphQLCallback<T> to(
-            @NonNull Consumer<Response<T>> onResponse,
-            @NonNull Consumer<ApolloException> onFailure) {
+    public static <T> DelegatingGraphQLCallback<T> to(
+        @NonNull Consumer<Response<T>> onResponse,
+        @NonNull Consumer<ApolloException> onFailure) {
         return new DelegatingGraphQLCallback<>(onResponse, onFailure);
     }
 

--- a/aws-android-sdk-appsync-tests/src/androidTest/java/com/amazonaws/mobileconnectors/appsync/client/LatchedGraphQLCallback.java
+++ b/aws-android-sdk-appsync-tests/src/androidTest/java/com/amazonaws/mobileconnectors/appsync/client/LatchedGraphQLCallback.java
@@ -5,11 +5,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-package com.amazonaws.mobileconnectors.appsync;
+package com.amazonaws.mobileconnectors.appsync.client;
 
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 
+import com.amazonaws.mobileconnectors.appsync.util.Await;
 import com.apollographql.apollo.GraphQLCall;
 import com.apollographql.apollo.api.Response;
 import com.apollographql.apollo.exception.ApolloException;
@@ -26,7 +27,7 @@ import java.util.concurrent.atomic.AtomicReference;
  * @param <T> The type of data in the GraphQL response, arriving at callback
  */
 @SuppressWarnings("unused")
-final class LatchedGraphQLCallback<T> extends GraphQLCall.Callback<T> {
+public final class LatchedGraphQLCallback<T> extends GraphQLCall.Callback<T> {
     private static final long REASONABLE_WAIT_TIME_MS = TimeUnit.SECONDS.toMillis(10);
 
     private final CountDownLatch responseLatch;
@@ -51,7 +52,7 @@ final class LatchedGraphQLCallback<T> extends GraphQLCall.Callback<T> {
      * @return A latched GraphQLCall.Callback
      */
     @NonNull
-    static <T> LatchedGraphQLCallback<T> instance() {
+    public static <T> LatchedGraphQLCallback<T> instance() {
         return new LatchedGraphQLCallback<>(REASONABLE_WAIT_TIME_MS);
     }
 
@@ -63,7 +64,7 @@ final class LatchedGraphQLCallback<T> extends GraphQLCall.Callback<T> {
      * @return A latched GraphQLCall.Callback
      */
     @NonNull
-    static <T> LatchedGraphQLCallback<T> instance(long waitTimeMs) {
+    public static <T> LatchedGraphQLCallback<T> instance(long waitTimeMs) {
         return new LatchedGraphQLCallback<>(waitTimeMs);
     }
 
@@ -86,7 +87,7 @@ final class LatchedGraphQLCallback<T> extends GraphQLCall.Callback<T> {
      * @throws RuntimeException If no response arrives before the timeout elapses
      */
     @Nullable
-    Response<T> awaitResponse() {
+    public Response<T> awaitResponse() {
         Await.latch(responseLatch, waitTimeMs);
         return responseContainer.get();
     }
@@ -102,7 +103,7 @@ final class LatchedGraphQLCallback<T> extends GraphQLCall.Callback<T> {
      *          is null, or contains errors, or has null data
      */
     @NonNull
-    Response<T> awaitSuccessfulResponse() {
+    public Response<T> awaitSuccessfulResponse() {
         Response<T> response = awaitResponse();
         if (response == null) {
             throw new RuntimeException("Null response.");
@@ -121,7 +122,7 @@ final class LatchedGraphQLCallback<T> extends GraphQLCall.Callback<T> {
      * @throws RuntimeException If the timeout elapses before a failure is received by callback
      */
     @Nullable
-    ApolloException awaitFailure() {
+    public ApolloException awaitFailure() {
         Await.latch(failureLatch, waitTimeMs);
         return failureContainer.get();
     }

--- a/aws-android-sdk-appsync-tests/src/androidTest/java/com/amazonaws/mobileconnectors/appsync/client/LatchedSubscriptionCallback.java
+++ b/aws-android-sdk-appsync-tests/src/androidTest/java/com/amazonaws/mobileconnectors/appsync/client/LatchedSubscriptionCallback.java
@@ -5,11 +5,13 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-package com.amazonaws.mobileconnectors.appsync;
+package com.amazonaws.mobileconnectors.appsync.client;
 
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 
+import com.amazonaws.mobileconnectors.appsync.AppSyncSubscriptionCall;
+import com.amazonaws.mobileconnectors.appsync.util.Await;
 import com.apollographql.apollo.api.Response;
 import com.apollographql.apollo.exception.ApolloException;
 
@@ -26,7 +28,7 @@ import java.util.concurrent.atomic.AtomicReference;
  * @param <T>
  */
 @SuppressWarnings({"unused", "UnusedReturnValue", "SameParameterValue", "WeakerAccess"})
-final class LatchedSubscriptionCallback<T> implements AppSyncSubscriptionCall.Callback<T> {
+public final class LatchedSubscriptionCallback<T> implements AppSyncSubscriptionCall.Callback<T> {
     private static final long REASONABLE_WAIT_TIME_MS = TimeUnit.SECONDS.toMillis(10);
 
     private final CountDownLatch failureLatch;
@@ -51,7 +53,7 @@ final class LatchedSubscriptionCallback<T> implements AppSyncSubscriptionCall.Ca
      * @param <T> The type of value expected in the subscription items
      * @return A latched subscription callback
      */
-    static <T> LatchedSubscriptionCallback<T> instance() {
+    public static <T> LatchedSubscriptionCallback<T> instance() {
         return new LatchedSubscriptionCallback<>(REASONABLE_WAIT_TIME_MS);
     }
 
@@ -140,7 +142,7 @@ final class LatchedSubscriptionCallback<T> implements AppSyncSubscriptionCall.Ca
      * @throws RuntimeException If unable to produce the requested number of responses, or if any
      *                          of the buffered responses are null, containing GraphQL errors, or null data
      */
-    List<Response<T>> awaitSuccessfulResponses(int desiredQuantity) {
+    public List<Response<T>> awaitSuccessfulResponses(int desiredQuantity) {
         awaitResponses(desiredQuantity);
         for (int pos = 0; pos < responses.size(); pos++) {
             Response<T> response = responses.get(pos);
@@ -160,7 +162,7 @@ final class LatchedSubscriptionCallback<T> implements AppSyncSubscriptionCall.Ca
      * a timeout elapses. When the timeout elapses, an error is raised.
      * @return The next response that was found on the subscription
      */
-    Response<T> awaitNextResponse() {
+    public Response<T> awaitNextResponse() {
         return awaitResponses(1).get(0);
     }
 
@@ -175,7 +177,7 @@ final class LatchedSubscriptionCallback<T> implements AppSyncSubscriptionCall.Ca
      *                          or if the next repsonse that arrives is not a valid, non-null
      *                          successful response
      */
-    Response<T> awaitNextSuccessfulResponse() {
+    public Response<T> awaitNextSuccessfulResponse() {
         return requireValidResponse(awaitNextResponse());
     }
 
@@ -185,7 +187,7 @@ final class LatchedSubscriptionCallback<T> implements AppSyncSubscriptionCall.Ca
      * Note that this method lasts a duration of time _at least_ as long as the timeout value.
      * @throws RuntimeException If a value is received before the timeout elapses
      */
-    void expectNoResponse() {
+    public void expectNoResponse() {
         Response<T> unexpectedResponse;
         try {
             unexpectedResponse = awaitNextResponse();
@@ -212,7 +214,7 @@ final class LatchedSubscriptionCallback<T> implements AppSyncSubscriptionCall.Ca
      * If no completion callback is received before the timeout, an error is thrown.
      * @throws RuntimeException If timeout elapses before completion callback occurs
      */
-    void awaitCompletion() {
+    public void awaitCompletion() {
         Await.latch(completionLatch, waitTimeMs);
     }
 

--- a/aws-android-sdk-appsync-tests/src/androidTest/java/com/amazonaws/mobileconnectors/appsync/client/LoggingPersistentMutationsCallback.java
+++ b/aws-android-sdk-appsync-tests/src/androidTest/java/com/amazonaws/mobileconnectors/appsync/client/LoggingPersistentMutationsCallback.java
@@ -5,11 +5,15 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-package com.amazonaws.mobileconnectors.appsync;
+package com.amazonaws.mobileconnectors.appsync.client;
 
 import android.util.Log;
 
-class LoggingPersistentMutationsCallback implements PersistentMutationsCallback {
+import com.amazonaws.mobileconnectors.appsync.PersistentMutationsCallback;
+import com.amazonaws.mobileconnectors.appsync.PersistentMutationsError;
+import com.amazonaws.mobileconnectors.appsync.PersistentMutationsResponse;
+
+final class LoggingPersistentMutationsCallback implements PersistentMutationsCallback {
     private static final String TAG = LoggingPersistentMutationsCallback.class.getName();
 
     private LoggingPersistentMutationsCallback() {}

--- a/aws-android-sdk-appsync-tests/src/androidTest/java/com/amazonaws/mobileconnectors/appsync/client/NoOpGraphQLCallback.java
+++ b/aws-android-sdk-appsync-tests/src/androidTest/java/com/amazonaws/mobileconnectors/appsync/client/NoOpGraphQLCallback.java
@@ -5,7 +5,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-package com.amazonaws.mobileconnectors.appsync;
+package com.amazonaws.mobileconnectors.appsync.client;
 
 import android.support.annotation.NonNull;
 
@@ -17,10 +17,10 @@ import com.apollographql.apollo.exception.ApolloException;
  * An {@link GraphQLCall.Callback} that does nothing.
  * @param <T> Type of data in the GraphQL response
  */
-final class NoOpGraphQLCallback<T> extends GraphQLCall.Callback<T> {
+public final class NoOpGraphQLCallback<T> extends GraphQLCall.Callback<T> {
     private NoOpGraphQLCallback() {}
 
-    static <T> NoOpGraphQLCallback<T> instance() {
+    public static <T> NoOpGraphQLCallback<T> instance() {
         return new NoOpGraphQLCallback<>();
     }
 

--- a/aws-android-sdk-appsync-tests/src/androidTest/java/com/amazonaws/mobileconnectors/appsync/client/TestConflictResolver.java
+++ b/aws-android-sdk-appsync-tests/src/androidTest/java/com/amazonaws/mobileconnectors/appsync/client/TestConflictResolver.java
@@ -5,20 +5,22 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-package com.amazonaws.mobileconnectors.appsync;
+package com.amazonaws.mobileconnectors.appsync.client;
 
 import android.util.Log;
 
+import com.amazonaws.mobileconnectors.appsync.ConflictResolutionHandler;
+import com.amazonaws.mobileconnectors.appsync.ConflictResolverInterface;
 import com.amazonaws.mobileconnectors.appsync.demo.UpdateArticleMutation;
 import com.amazonaws.mobileconnectors.appsync.demo.type.UpdateArticleInput;
 
 import org.json.JSONException;
 import org.json.JSONObject;
 
-class TestConflictResolver implements ConflictResolverInterface {
+final class TestConflictResolver implements ConflictResolverInterface {
     private static final String TAG = TestConflictResolver.class.getSimpleName();
 
-    @SuppressWarnings("NullableProblems")
+    @SuppressWarnings({"NullableProblems", "ConstantConditions"})
     @Override
     public void resolveConflict(
             ConflictResolutionHandler handler,

--- a/aws-android-sdk-appsync-tests/src/androidTest/java/com/amazonaws/mobileconnectors/appsync/client/package-info.java
+++ b/aws-android-sdk-appsync-tests/src/androidTest/java/com/amazonaws/mobileconnectors/appsync/client/package-info.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2018-2020 Amazon.com,
+ * Inc. or its affiliates. All Rights Reserved.
+ * <p>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * This package contains code for interaction with an
+ * {@link com.amazonaws.mobileconnectors.appsync.AWSAppSyncClient},
+ * itself. The {@link com.amazonaws.mobileconnectors.appsync.client.AWSAppSyncClients}
+ * is a factory class to create various instances of the client,
+ * permuted by different authentication schemes.
+ *
+ * {@link com.amazonaws.mobileconnectors.appsync.client.LatchedGraphQLCallback}
+ * and {@link com.amazonaws.mobileconnectors.appsync.client.LatchedSubscriptionCallback}
+ * are useful for making async calls into synchronous calls, so that you can assert
+ * outcomes after the result is furnished.
+ *
+ * {@link com.amazonaws.mobileconnectors.appsync.client.NoOpGraphQLCallback}
+ * and {@link com.amazonaws.mobileconnectors.appsync.client.DelegatingGraphQLCallback}
+ * are utility callbacks to reduce boiler-plate by either doing nothing, or by
+ * supplying lambdas instead of a verbose, anonymous instance
+ * of {@link com.apollographql.apollo.GraphQLCall.Callback}.
+ */
+package com.amazonaws.mobileconnectors.appsync.client;

--- a/aws-android-sdk-appsync-tests/src/androidTest/java/com/amazonaws/mobileconnectors/appsync/identity/CustomCognitoUserPool.java
+++ b/aws-android-sdk-appsync-tests/src/androidTest/java/com/amazonaws/mobileconnectors/appsync/identity/CustomCognitoUserPool.java
@@ -5,13 +5,14 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-package com.amazonaws.mobileconnectors.appsync;
+package com.amazonaws.mobileconnectors.appsync.identity;
 
 import android.support.annotation.NonNull;
 import android.util.Log;
 
 import com.amazonaws.mobile.client.results.SignInResult;
 import com.amazonaws.mobile.config.AWSConfiguration;
+import com.amazonaws.mobileconnectors.appsync.util.Await;
 import com.amazonaws.mobileconnectors.cognitoidentityprovider.CognitoDevice;
 import com.amazonaws.mobileconnectors.cognitoidentityprovider.CognitoUserPool;
 import com.amazonaws.mobileconnectors.cognitoidentityprovider.CognitoUserSession;
@@ -23,17 +24,17 @@ import com.amazonaws.mobileconnectors.cognitoidentityprovider.handlers.Authentic
 
 import static android.support.test.InstrumentationRegistry.getTargetContext;
 
-final class CustomCognitoUserPool {
+public final class CustomCognitoUserPool {
     private static final String TAG = CustomCognitoUserPool.class.getSimpleName();
 
     private CustomCognitoUserPool() {}
 
     @NonNull
-    static String setup() {
+    public static String setup() {
         // Sign in the user.
         Await.result((Await.ResultErrorEmitter<SignInResult, RuntimeException>) (onResult, onError) -> {
-            DelegatingCallback<SignInResult> callback =
-                DelegatingCallback.to(onResult, exception -> onError.accept(new RuntimeException(exception)));
+            DelegatingMobileClientCallback<SignInResult> callback =
+                DelegatingMobileClientCallback.to(onResult, exception -> onError.accept(new RuntimeException(exception)));
             TestAWSMobileClient.instance(getTargetContext())
                 .signIn("appsync-multi-auth-test-user", "P@ssw0rd!", null, callback);
         });

--- a/aws-android-sdk-appsync-tests/src/androidTest/java/com/amazonaws/mobileconnectors/appsync/identity/DelayedCognitoCredentialsProvider.java
+++ b/aws-android-sdk-appsync-tests/src/androidTest/java/com/amazonaws/mobileconnectors/appsync/identity/DelayedCognitoCredentialsProvider.java
@@ -5,7 +5,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-package com.amazonaws.mobileconnectors.appsync;
+package com.amazonaws.mobileconnectors.appsync.identity;
 
 import android.content.Context;
 import android.support.test.InstrumentationRegistry;
@@ -13,14 +13,15 @@ import android.support.test.InstrumentationRegistry;
 import com.amazonaws.auth.AWSCredentials;
 import com.amazonaws.auth.AWSCredentialsProvider;
 import com.amazonaws.auth.CognitoCachingCredentialsProvider;
+import com.amazonaws.mobileconnectors.appsync.util.Sleep;
 import com.amazonaws.regions.Regions;
 
 // TODO: Why does this exist?
-final class DelayedCognitoCredentialsProvider implements AWSCredentialsProvider {
+public final class DelayedCognitoCredentialsProvider implements AWSCredentialsProvider {
     private final AWSCredentialsProvider credentialsProvider;
     private final long credentialsDelay;
 
-    DelayedCognitoCredentialsProvider(String cognitoIdentityPoolID, Regions region, long credentialsDelay) {
+    public DelayedCognitoCredentialsProvider(String cognitoIdentityPoolID, Regions region, long credentialsDelay) {
         Context context = InstrumentationRegistry.getContext();
         this.credentialsProvider = new CognitoCachingCredentialsProvider(context, cognitoIdentityPoolID, region);
         this.credentialsDelay = credentialsDelay;

--- a/aws-android-sdk-appsync-tests/src/androidTest/java/com/amazonaws/mobileconnectors/appsync/identity/DelegatingMobileClientCallback.java
+++ b/aws-android-sdk-appsync-tests/src/androidTest/java/com/amazonaws/mobileconnectors/appsync/identity/DelegatingMobileClientCallback.java
@@ -1,15 +1,9 @@
-/*
- * Copyright 2020 Amazon.com,
- * Inc. or its affiliates. All Rights Reserved.
- * <p>
- * SPDX-License-Identifier: Apache-2.0
- */
-
-package com.amazonaws.mobileconnectors.appsync;
+package com.amazonaws.mobileconnectors.appsync.identity;
 
 import android.support.annotation.Nullable;
 
 import com.amazonaws.mobile.client.Callback;
+import com.amazonaws.mobileconnectors.appsync.util.Consumer;
 
 /**
  * An AWS Mobile Client {@link Callback} which passes any received result/error
@@ -18,11 +12,11 @@ import com.amazonaws.mobile.client.Callback;
  * That consumer can deal with the exception, from there on.
  * @param <T> Type of result received in the callback
  */
-final class DelegatingCallback<T> implements Callback<T> {
+final class DelegatingMobileClientCallback<T> implements Callback<T> {
     private final Consumer<T> onResult;
     private final Consumer<Exception> onError;
 
-    private DelegatingCallback(Consumer<T> onResult, Consumer<Exception> onError) {
+    private DelegatingMobileClientCallback(Consumer<T> onResult, Consumer<Exception> onError) {
         this.onResult = onResult;
         this.onError = onError;
     }
@@ -34,9 +28,9 @@ final class DelegatingCallback<T> implements Callback<T> {
      * @param <T> Type of result data
      * @return An AWS Mobile Client callback which delegates values to one of two consumers.
      */
-    static <T> DelegatingCallback<T> to(
-            @Nullable Consumer<T> onResult, @Nullable Consumer<Exception> onError) {
-        return new DelegatingCallback<>(
+    static <T> DelegatingMobileClientCallback<T> to(
+        @Nullable Consumer<T> onResult, @Nullable Consumer<Exception> onError) {
+        return new DelegatingMobileClientCallback<>(
             onResult != null ? onResult : DefaultConsumer.instance(),
             onError != null ? onError : DefaultConsumer.instance()
         );

--- a/aws-android-sdk-appsync-tests/src/androidTest/java/com/amazonaws/mobileconnectors/appsync/identity/LatchedMobileClientCallback.java
+++ b/aws-android-sdk-appsync-tests/src/androidTest/java/com/amazonaws/mobileconnectors/appsync/identity/LatchedMobileClientCallback.java
@@ -1,13 +1,14 @@
 /*
- * Copyright 2020 Amazon.com,
+ * Copyright 2018-2020 Amazon.com,
  * Inc. or its affiliates. All Rights Reserved.
  * <p>
  * SPDX-License-Identifier: Apache-2.0
  */
 
-package com.amazonaws.mobileconnectors.appsync;
+package com.amazonaws.mobileconnectors.appsync.identity;
 
 import com.amazonaws.mobile.client.Callback;
+import com.amazonaws.mobileconnectors.appsync.util.Await;
 
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
@@ -18,7 +19,7 @@ import java.util.concurrent.atomic.AtomicReference;
  * to block the calling thread of execution until a result/error is received.
  * @param <T> The type of result expected
  */
-final class LatchedCallback<T> implements Callback<T> {
+final class LatchedMobileClientCallback<T> implements Callback<T> {
     private static final long REASONABLE_WAIT_TIME_MS = TimeUnit.SECONDS.toMillis(10);
 
     private final CountDownLatch resultLatch;
@@ -27,7 +28,7 @@ final class LatchedCallback<T> implements Callback<T> {
     private final AtomicReference<Exception> errorContainer;
     private final long waitTimeMs;
 
-    private LatchedCallback(long waitTimeMs) {
+    private LatchedMobileClientCallback(long waitTimeMs) {
         this.resultLatch = new CountDownLatch(1);
         this.resultContainer = new AtomicReference<>();
         this.errorLatch = new CountDownLatch(1);
@@ -42,8 +43,8 @@ final class LatchedCallback<T> implements Callback<T> {
      * @param <T> Type of result provided to callback
      * @return A latched callback
      */
-    static <T> LatchedCallback<T> instance() {
-        return new LatchedCallback<>(REASONABLE_WAIT_TIME_MS);
+    static <T> LatchedMobileClientCallback<T> instance() {
+        return new LatchedMobileClientCallback<>(REASONABLE_WAIT_TIME_MS);
     }
 
     /**
@@ -55,8 +56,8 @@ final class LatchedCallback<T> implements Callback<T> {
      * @return A latched callback
      */
     @SuppressWarnings("unused")
-    static <T> LatchedCallback<T> instance(long waitTimeMs) {
-        return new LatchedCallback<>(waitTimeMs);
+    static <T> LatchedMobileClientCallback<T> instance(long waitTimeMs) {
+        return new LatchedMobileClientCallback<>(waitTimeMs);
     }
 
     @Override

--- a/aws-android-sdk-appsync-tests/src/androidTest/java/com/amazonaws/mobileconnectors/appsync/identity/TestAWSMobileClient.java
+++ b/aws-android-sdk-appsync-tests/src/androidTest/java/com/amazonaws/mobileconnectors/appsync/identity/TestAWSMobileClient.java
@@ -5,7 +5,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-package com.amazonaws.mobileconnectors.appsync;
+package com.amazonaws.mobileconnectors.appsync.identity;
 
 import android.content.Context;
 import android.support.annotation.NonNull;
@@ -20,13 +20,13 @@ import java.util.Objects;
  * The singleton instance of the client is initialized in a synchronous way, and is
  * usable as soon as it is returned.
  */
-final class TestAWSMobileClient {
+public final class TestAWSMobileClient {
     private static AWSMobileClient instance;
 
-    static synchronized AWSMobileClient instance(@NonNull Context context) {
+    public static synchronized AWSMobileClient instance(@NonNull Context context) {
         Objects.requireNonNull(context);
         if (instance == null) {
-            LatchedCallback<UserStateDetails> callback = LatchedCallback.instance();
+            LatchedMobileClientCallback<UserStateDetails> callback = LatchedMobileClientCallback.instance();
             AWSMobileClient.getInstance().initialize(context, callback);
             callback.awaitResult();
             instance = AWSMobileClient.getInstance();

--- a/aws-android-sdk-appsync-tests/src/androidTest/java/com/amazonaws/mobileconnectors/appsync/identity/package-info.java
+++ b/aws-android-sdk-appsync-tests/src/androidTest/java/com/amazonaws/mobileconnectors/appsync/identity/package-info.java
@@ -1,0 +1,13 @@
+/*
+ * Copyright 2018-2020 Amazon.com,
+ * Inc. or its affiliates. All Rights Reserved.
+ * <p>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * This package deals with Cognito, and the AWSMobileClient, and other
+ * concerns related to bootstrapping identities. Identities are used
+ * by the AWSAppSyncClient when making GraphQL requests.
+ */
+package com.amazonaws.mobileconnectors.appsync.identity;

--- a/aws-android-sdk-appsync-tests/src/androidTest/java/com/amazonaws/mobileconnectors/appsync/models/PostCruds.java
+++ b/aws-android-sdk-appsync-tests/src/androidTest/java/com/amazonaws/mobileconnectors/appsync/models/PostCruds.java
@@ -5,10 +5,11 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-package com.amazonaws.mobileconnectors.appsync;
+package com.amazonaws.mobileconnectors.appsync.models;
 
 import android.util.Log;
 
+import com.amazonaws.mobileconnectors.appsync.AWSAppSyncClient;
 import com.amazonaws.mobileconnectors.appsync.demo.AddPostMutation;
 import com.amazonaws.mobileconnectors.appsync.demo.DeletePostMutation;
 import com.amazonaws.mobileconnectors.appsync.demo.GetPostQuery;
@@ -23,10 +24,10 @@ import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 
-final class PostCruds {
+public final class PostCruds {
     private static final String TAG = PostCruds.class.getName();
 
-    static void test(Collection<AWSAppSyncClient> awsAppSyncClients) {
+    public static void test(Collection<AWSAppSyncClient> awsAppSyncClients) {
         for (final AWSAppSyncClient awsAppSyncClient : awsAppSyncClients) {
             assertNotNull(awsAppSyncClient);
             final String title = "Home [Scene Six]";

--- a/aws-android-sdk-appsync-tests/src/androidTest/java/com/amazonaws/mobileconnectors/appsync/models/Posts.java
+++ b/aws-android-sdk-appsync-tests/src/androidTest/java/com/amazonaws/mobileconnectors/appsync/models/Posts.java
@@ -5,10 +5,14 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-package com.amazonaws.mobileconnectors.appsync;
+package com.amazonaws.mobileconnectors.appsync.models;
 
 import android.util.Log;
 
+import com.amazonaws.mobileconnectors.appsync.AWSAppSyncClient;
+import com.amazonaws.mobileconnectors.appsync.AppSyncMutationCall;
+import com.amazonaws.mobileconnectors.appsync.client.DelegatingGraphQLCallback;
+import com.amazonaws.mobileconnectors.appsync.client.LatchedGraphQLCallback;
 import com.amazonaws.mobileconnectors.appsync.demo.AddPostMissingRequiredFieldsMutation;
 import com.amazonaws.mobileconnectors.appsync.demo.AddPostMutation;
 import com.amazonaws.mobileconnectors.appsync.demo.AddPostRequiredFieldsOnlyMutation;
@@ -20,6 +24,8 @@ import com.amazonaws.mobileconnectors.appsync.demo.type.CreatePostInput;
 import com.amazonaws.mobileconnectors.appsync.demo.type.DeletePostInput;
 import com.amazonaws.mobileconnectors.appsync.demo.type.UpdatePostInput;
 import com.amazonaws.mobileconnectors.appsync.fetcher.AppSyncResponseFetchers;
+import com.amazonaws.mobileconnectors.appsync.util.Await;
+import com.amazonaws.mobileconnectors.appsync.util.Sleep;
 import com.apollographql.apollo.api.Response;
 import com.apollographql.apollo.fetcher.ResponseFetcher;
 import com.apollographql.apollo.internal.fetcher.CacheAndNetworkFetcher;
@@ -33,7 +39,7 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 
 @SuppressWarnings({"UnusedReturnValue", "SameParameterValue"})
-final class Posts {
+public final class Posts {
     private static final String TAG = Posts.class.getName();
 
     private Posts() {}
@@ -47,8 +53,8 @@ final class Posts {
      * @param content Content of post
      * @return A response from AppSync
      */
-    static Response<AddPostMutation.Data> add(
-            AWSAppSyncClient client, String title, String author, String url, String content) {
+    public static Response<AddPostMutation.Data> add(
+        AWSAppSyncClient client, String title, String author, String url, String content) {
         LatchedGraphQLCallback<AddPostMutation.Data> callback = LatchedGraphQLCallback.instance();
         client.mutate(
             AddPostMutation.builder()
@@ -76,7 +82,7 @@ final class Posts {
      * @param postId ID of Post to delete
      * @return A Response from AppSync
      */
-    static Response<DeletePostMutation.Data> delete(AWSAppSyncClient client, String postId) {
+    public static Response<DeletePostMutation.Data> delete(AWSAppSyncClient client, String postId) {
         LatchedGraphQLCallback<DeletePostMutation.Data> callback = LatchedGraphQLCallback.instance();
         client.mutate(
             DeletePostMutation.builder()
@@ -99,8 +105,8 @@ final class Posts {
      * @param content New content for post with given ID
      * @return A Response from AppSync
      */
-    static Response<UpdatePostMutation.Data> update(
-            AWSAppSyncClient client, String postId, String content) {
+    public static Response<UpdatePostMutation.Data> update(
+        AWSAppSyncClient client, String postId, String content) {
         LatchedGraphQLCallback<UpdatePostMutation.Data> callback = LatchedGraphQLCallback.instance();
         client.mutate(
             UpdatePostMutation.builder()
@@ -124,8 +130,8 @@ final class Posts {
      * @param postId ID of a post for which to query
      * @return cached/network responses, labeled in a Map as "NETWORK" and/or "CACHE"
      */
-    static Map<String, Response<GetPostQuery.Data>> query(
-            AWSAppSyncClient client, ResponseFetcher responseFetcher, String postId) {
+    public static Map<String, Response<GetPostQuery.Data>> query(
+        AWSAppSyncClient client, ResponseFetcher responseFetcher, String postId) {
         Log.d(TAG, "Calling Query queryPost with responseFetcher: " + responseFetcher.toString());
         int expectedResponseCount =
             responseFetcher.equals(AppSyncResponseFetchers.CACHE_AND_NETWORK) ? 2 : 1;
@@ -155,8 +161,8 @@ final class Posts {
         return getPostQueryResponses;
     }
 
-    static Map<String, Response<AllPostsQuery.Data>> list(
-            AWSAppSyncClient client, ResponseFetcher responseFetcher) {
+    public static Map<String, Response<AllPostsQuery.Data>> list(
+        AWSAppSyncClient client, ResponseFetcher responseFetcher) {
         int expectedResponseCount =
             responseFetcher.equals(AppSyncResponseFetchers.CACHE_AND_NETWORK) ? 2 : 1;
         CountDownLatch queryCountDownLatch = new CountDownLatch(expectedResponseCount);
@@ -224,7 +230,7 @@ final class Posts {
         call.cancel();
     }
 
-    static Response<AddPostMissingRequiredFieldsMutation.Data> addMissingRequiredFields(
+    public static Response<AddPostMissingRequiredFieldsMutation.Data> addMissingRequiredFields(
         AWSAppSyncClient client, String title, String author, String url, String content) {
         LatchedGraphQLCallback<AddPostMissingRequiredFieldsMutation.Data> callback = LatchedGraphQLCallback.instance();
         client.mutate(
@@ -244,7 +250,7 @@ final class Posts {
         return callback.awaitResponse();
     }
 
-    static Response<AddPostRequiredFieldsOnlyMutation.Data> addRequiredFieldsOnly(
+    public static Response<AddPostRequiredFieldsOnlyMutation.Data> addRequiredFieldsOnly(
         AWSAppSyncClient client, String title, String author, String url, String content) {
         LatchedGraphQLCallback<AddPostRequiredFieldsOnlyMutation.Data> callback =
             LatchedGraphQLCallback.instance();
@@ -265,7 +271,7 @@ final class Posts {
         return callback.awaitResponse();
     }
 
-    static void validate(Response<GetPostQuery.Data> response, String postId, String authMode) {
+    public static void validate(Response<GetPostQuery.Data> response, String postId, String authMode) {
         assertNotNull(response);
         assertNotNull(response.data());
         assertNotNull(response.data().getPost());

--- a/aws-android-sdk-appsync-tests/src/androidTest/java/com/amazonaws/mobileconnectors/appsync/models/package-info.java
+++ b/aws-android-sdk-appsync-tests/src/androidTest/java/com/amazonaws/mobileconnectors/appsync/models/package-info.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright 2018-2020 Amazon.com,
+ * Inc. or its affiliates. All Rights Reserved.
+ * <p>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * This package contains utilities for interacting with code generated model classes.
+ *
+ * {@link com.amazonaws.mobileconnectors.appsync.models.Posts} simplifies CRUD operations
+ * using an AppSync client.
+ *
+ * {@link com.amazonaws.mobileconnectors.appsync.models.PostCruds} is a test snippet
+ * that can be recycled across various instrumentation tests, to test if CRUD
+ * operations are working for the Post model. Underneath the hood, it makes a bunch of calls
+ * to {@link com.amazonaws.mobileconnectors.appsync.models.Posts}. :-).
+ */
+package com.amazonaws.mobileconnectors.appsync.models;

--- a/aws-android-sdk-appsync-tests/src/androidTest/java/com/amazonaws/mobileconnectors/appsync/tests/ComplexObjectsInstrumentationTests.java
+++ b/aws-android-sdk-appsync-tests/src/androidTest/java/com/amazonaws/mobileconnectors/appsync/tests/ComplexObjectsInstrumentationTests.java
@@ -5,10 +5,14 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-package com.amazonaws.mobileconnectors.appsync;
+package com.amazonaws.mobileconnectors.appsync.tests;
 
 import android.support.test.runner.AndroidJUnit4;
 
+import com.amazonaws.mobileconnectors.appsync.AWSAppSyncClient;
+import com.amazonaws.mobileconnectors.appsync.client.AWSAppSyncClients;
+import com.amazonaws.mobileconnectors.appsync.client.DelegatingGraphQLCallback;
+import com.amazonaws.mobileconnectors.appsync.client.LatchedGraphQLCallback;
 import com.amazonaws.mobileconnectors.appsync.demo.AllArticlesQuery;
 import com.amazonaws.mobileconnectors.appsync.demo.CreateArticle2Mutation;
 import com.amazonaws.mobileconnectors.appsync.demo.CreateArticleMutation;
@@ -17,6 +21,9 @@ import com.amazonaws.mobileconnectors.appsync.demo.type.CreateArticleInput;
 import com.amazonaws.mobileconnectors.appsync.demo.type.S3ObjectInput;
 import com.amazonaws.mobileconnectors.appsync.demo.type.UpdateArticleInput;
 import com.amazonaws.mobileconnectors.appsync.fetcher.AppSyncResponseFetchers;
+import com.amazonaws.mobileconnectors.appsync.identity.CustomCognitoUserPool;
+import com.amazonaws.mobileconnectors.appsync.util.Await;
+import com.amazonaws.mobileconnectors.appsync.util.DataFile;
 import com.apollographql.apollo.api.Response;
 import com.apollographql.apollo.fetcher.ResponseFetcher;
 
@@ -39,7 +46,7 @@ import static org.junit.Assert.assertTrue;
  * @see <a href="http://d.android.com/tools/testing">Testing documentation</a>
  */
 @RunWith(AndroidJUnit4.class)
-public class AWSAppSyncComplexObjectsInstrumentationTests {
+public class ComplexObjectsInstrumentationTests {
     private static final String REGION = "us-west-2";
     private static final String BUCKET_NAME = "aws-appsync-tests-android163429-dev";
 

--- a/aws-android-sdk-appsync-tests/src/androidTest/java/com/amazonaws/mobileconnectors/appsync/tests/ConflictManagementInstrumentationTest.java
+++ b/aws-android-sdk-appsync-tests/src/androidTest/java/com/amazonaws/mobileconnectors/appsync/tests/ConflictManagementInstrumentationTest.java
@@ -5,14 +5,20 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-package com.amazonaws.mobileconnectors.appsync;
+package com.amazonaws.mobileconnectors.appsync.tests;
 
 import android.support.test.runner.AndroidJUnit4;
 
+import com.amazonaws.mobileconnectors.appsync.AWSAppSyncClient;
+import com.amazonaws.mobileconnectors.appsync.client.AWSAppSyncClients;
+import com.amazonaws.mobileconnectors.appsync.ConflictResolutionFailedException;
+import com.amazonaws.mobileconnectors.appsync.client.LatchedGraphQLCallback;
+import com.amazonaws.mobileconnectors.appsync.client.NoOpGraphQLCallback;
 import com.amazonaws.mobileconnectors.appsync.demo.CreateArticleMutation;
 import com.amazonaws.mobileconnectors.appsync.demo.UpdateArticleMutation;
 import com.amazonaws.mobileconnectors.appsync.demo.type.CreateArticleInput;
 import com.amazonaws.mobileconnectors.appsync.demo.type.UpdateArticleInput;
+import com.amazonaws.mobileconnectors.appsync.identity.CustomCognitoUserPool;
 import com.apollographql.apollo.api.Response;
 
 import org.junit.BeforeClass;
@@ -29,7 +35,7 @@ import static org.junit.Assert.assertTrue;
  * @see <a href="http://d.android.com/tools/testing">Testing documentation</a>
  */
 @RunWith(AndroidJUnit4.class)
-public class AWSAppSyncConflictManagementInstrumentationTest {
+public class ConflictManagementInstrumentationTest {
     /**
      * We will do one add and 5 updates that try out the various paths of conflict
      * management. This function will exit once the add is completed and the

--- a/aws-android-sdk-appsync-tests/src/androidTest/java/com/amazonaws/mobileconnectors/appsync/tests/MultiClientInstrumentationTest.java
+++ b/aws-android-sdk-appsync-tests/src/androidTest/java/com/amazonaws/mobileconnectors/appsync/tests/MultiClientInstrumentationTest.java
@@ -5,13 +5,22 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-package com.amazonaws.mobileconnectors.appsync;
+package com.amazonaws.mobileconnectors.appsync.tests;
 
 import android.support.test.runner.AndroidJUnit4;
 import android.util.Log;
 
 import com.amazonaws.mobile.client.AWSMobileClient;
 import com.amazonaws.mobile.config.AWSConfiguration;
+import com.amazonaws.mobileconnectors.appsync.AWSAppSyncClient;
+import com.amazonaws.mobileconnectors.appsync.AWSAppSyncClientException;
+import com.amazonaws.mobileconnectors.appsync.ClearCacheException;
+import com.amazonaws.mobileconnectors.appsync.ClearCacheOptions;
+import com.amazonaws.mobileconnectors.appsync.SyncStore;
+import com.amazonaws.mobileconnectors.appsync.client.LatchedGraphQLCallback;
+import com.amazonaws.mobileconnectors.appsync.client.NoOpGraphQLCallback;
+import com.amazonaws.mobileconnectors.appsync.client.AWSAppSyncClients;
+import com.amazonaws.mobileconnectors.appsync.identity.CustomCognitoUserPool;
 import com.amazonaws.mobileconnectors.appsync.demo.AddPostMutation;
 import com.amazonaws.mobileconnectors.appsync.demo.AllPostsQuery;
 import com.amazonaws.mobileconnectors.appsync.demo.GetPostQuery;
@@ -19,7 +28,13 @@ import com.amazonaws.mobileconnectors.appsync.demo.UpdatePostMutation;
 import com.amazonaws.mobileconnectors.appsync.demo.type.CreatePostInput;
 import com.amazonaws.mobileconnectors.appsync.demo.type.UpdatePostInput;
 import com.amazonaws.mobileconnectors.appsync.fetcher.AppSyncResponseFetchers;
+import com.amazonaws.mobileconnectors.appsync.models.PostCruds;
+import com.amazonaws.mobileconnectors.appsync.models.Posts;
 import com.amazonaws.mobileconnectors.appsync.sigv4.BasicAPIKeyAuthProvider;
+import com.amazonaws.mobileconnectors.appsync.util.Await;
+import com.amazonaws.mobileconnectors.appsync.util.JsonExtract;
+import com.amazonaws.mobileconnectors.appsync.util.Sleep;
+import com.amazonaws.mobileconnectors.appsync.util.Wifi;
 import com.amazonaws.regions.Regions;
 import com.apollographql.apollo.GraphQLCall;
 import com.apollographql.apollo.api.Operation.Variables;
@@ -49,9 +64,6 @@ import java.util.concurrent.TimeUnit;
 import javax.annotation.Nonnull;
 
 import static android.support.test.InstrumentationRegistry.getTargetContext;
-import static com.amazonaws.mobileconnectors.appsync.AWSAppSyncClient.DEFAULT_DELTA_SYNC_SQL_STORE_NAME;
-import static com.amazonaws.mobileconnectors.appsync.AWSAppSyncClient.DEFAULT_MUTATION_SQL_STORE_NAME;
-import static com.amazonaws.mobileconnectors.appsync.AWSAppSyncClient.DEFAULT_QUERY_SQL_STORE_NAME;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
@@ -66,8 +78,8 @@ import static org.junit.Assert.fail;
  * @see <a href="http://d.android.com/tools/testing">Testing documentation</a>
  */
 @RunWith(AndroidJUnit4.class)
-public class AWSAppSyncMultiClientInstrumentationTest {
-    private static final String TAG = AWSAppSyncMultiClientInstrumentationTest.class.getSimpleName();
+public class MultiClientInstrumentationTest {
+    private static final String TAG = MultiClientInstrumentationTest.class.getSimpleName();
     private static String idToken = null;
 
     @BeforeClass
@@ -724,10 +736,7 @@ public class AWSAppSyncMultiClientInstrumentationTest {
             .context(getTargetContext())
             .awsConfiguration(awsConfiguration)
             .build();
-        assertNotNull(awsAppSyncClient.mSyncStore);
-        assertEquals(DEFAULT_QUERY_SQL_STORE_NAME, awsAppSyncClient.querySqlStoreName);
-        assertEquals(DEFAULT_MUTATION_SQL_STORE_NAME, awsAppSyncClient.mutationSqlStoreName);
-        assertEquals(DEFAULT_DELTA_SYNC_SQL_STORE_NAME, awsAppSyncClient.deltaSyncSqlStoreName);
+        SyncStore.validate(awsAppSyncClient, null);
     }
 
     @Test

--- a/aws-android-sdk-appsync-tests/src/androidTest/java/com/amazonaws/mobileconnectors/appsync/tests/QueryInstrumentationTest.java
+++ b/aws-android-sdk-appsync-tests/src/androidTest/java/com/amazonaws/mobileconnectors/appsync/tests/QueryInstrumentationTest.java
@@ -5,7 +5,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-package com.amazonaws.mobileconnectors.appsync;
+package com.amazonaws.mobileconnectors.appsync.tests;
 
 import android.content.Context;
 import android.net.wifi.WifiManager;
@@ -13,6 +13,13 @@ import android.support.annotation.NonNull;
 import android.support.test.InstrumentationRegistry;
 import android.util.Log;
 
+import com.amazonaws.mobileconnectors.appsync.AWSAppSyncClient;
+import com.amazonaws.mobileconnectors.appsync.client.AWSAppSyncClients;
+import com.amazonaws.mobileconnectors.appsync.AppSyncMutationCall;
+import com.amazonaws.mobileconnectors.appsync.client.LatchedGraphQLCallback;
+import com.amazonaws.mobileconnectors.appsync.client.NoOpGraphQLCallback;
+import com.amazonaws.mobileconnectors.appsync.models.PostCruds;
+import com.amazonaws.mobileconnectors.appsync.models.Posts;
 import com.amazonaws.mobileconnectors.appsync.demo.AddPostMutation;
 import com.amazonaws.mobileconnectors.appsync.demo.AllPostsQuery;
 import com.amazonaws.mobileconnectors.appsync.demo.GetPostQuery;
@@ -20,6 +27,9 @@ import com.amazonaws.mobileconnectors.appsync.demo.UpdatePostMutation;
 import com.amazonaws.mobileconnectors.appsync.demo.type.CreatePostInput;
 import com.amazonaws.mobileconnectors.appsync.demo.type.UpdatePostInput;
 import com.amazonaws.mobileconnectors.appsync.fetcher.AppSyncResponseFetchers;
+import com.amazonaws.mobileconnectors.appsync.identity.CustomCognitoUserPool;
+import com.amazonaws.mobileconnectors.appsync.util.Await;
+import com.amazonaws.mobileconnectors.appsync.util.Sleep;
 import com.apollographql.apollo.GraphQLCall;
 import com.apollographql.apollo.api.Error;
 import com.apollographql.apollo.api.Operation;
@@ -49,8 +59,8 @@ import static org.junit.Assert.fail;
 /**
  * Tests for base and delta queries, list/get of models.
  */
-public final class AWSAppSyncQueryInstrumentationTest {
-    private static final String TAG = AWSAppSyncQueryInstrumentationTest.class.getSimpleName();
+public final class QueryInstrumentationTest {
+    private static final String TAG = QueryInstrumentationTest.class.getSimpleName();
     private static final long REASONABLE_WAIT_TIME_MS = TimeUnit.SECONDS.toMillis(10);
     private static final long EXTENDED_WAIT_TIME_MS = TimeUnit.SECONDS.toMillis(30);
 

--- a/aws-android-sdk-appsync-tests/src/androidTest/java/com/amazonaws/mobileconnectors/appsync/tests/SubscriptionInstrumentationTest.java
+++ b/aws-android-sdk-appsync-tests/src/androidTest/java/com/amazonaws/mobileconnectors/appsync/tests/SubscriptionInstrumentationTest.java
@@ -5,13 +5,19 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-package com.amazonaws.mobileconnectors.appsync;
+package com.amazonaws.mobileconnectors.appsync.tests;
 
 import android.content.Context;
 import android.net.wifi.WifiManager;
 import android.support.test.InstrumentationRegistry;
 import android.util.Log;
 
+import com.amazonaws.mobileconnectors.appsync.AWSAppSyncClient;
+import com.amazonaws.mobileconnectors.appsync.client.AWSAppSyncClients;
+import com.amazonaws.mobileconnectors.appsync.AppSyncSubscriptionCall;
+import com.amazonaws.mobileconnectors.appsync.client.LatchedSubscriptionCallback;
+import com.amazonaws.mobileconnectors.appsync.client.NoOpGraphQLCallback;
+import com.amazonaws.mobileconnectors.appsync.models.Posts;
 import com.amazonaws.mobileconnectors.appsync.demo.AddPostMutation;
 import com.amazonaws.mobileconnectors.appsync.demo.CommentOnEventMutation;
 import com.amazonaws.mobileconnectors.appsync.demo.NewCommentOnEventSubscription;
@@ -22,6 +28,8 @@ import com.amazonaws.mobileconnectors.appsync.demo.OnDeletePostSubscription;
 import com.amazonaws.mobileconnectors.appsync.demo.OnUpdateArticleSubscription;
 import com.amazonaws.mobileconnectors.appsync.demo.OnUpdatePostSubscription;
 import com.amazonaws.mobileconnectors.appsync.demo.UpdatePostMutation;
+import com.amazonaws.mobileconnectors.appsync.identity.CustomCognitoUserPool;
+import com.amazonaws.mobileconnectors.appsync.util.Sleep;
 import com.apollographql.apollo.api.Response;
 
 import org.junit.After;
@@ -35,8 +43,8 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
-public final class AWSAppSyncSubscriptionInstrumentationTest {
-    private static final String TAG = AWSAppSyncSubscriptionInstrumentationTest.class.getSimpleName();
+public final class SubscriptionInstrumentationTest {
+    private static final String TAG = SubscriptionInstrumentationTest.class.getSimpleName();
     private static final long REASONABLE_WAIT_TIME_MS = TimeUnit.SECONDS.toMillis(10);
     private static final long EXTENDED_WAIT_TIME_MS = TimeUnit.SECONDS.toMillis(5);
 

--- a/aws-android-sdk-appsync-tests/src/androidTest/java/com/amazonaws/mobileconnectors/appsync/tests/package-info.java
+++ b/aws-android-sdk-appsync-tests/src/androidTest/java/com/amazonaws/mobileconnectors/appsync/tests/package-info.java
@@ -1,0 +1,12 @@
+/*
+ * Copyright 2018-2020 Amazon.com,
+ * Inc. or its affiliates. All Rights Reserved.
+ * <p>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * This package contains the actual Android instrumentation test classes
+ * uses to test AppSync. These files are named like [WhatsBeingTested]InstrumentationTest.java.
+ */
+package com.amazonaws.mobileconnectors.appsync.tests;

--- a/aws-android-sdk-appsync-tests/src/androidTest/java/com/amazonaws/mobileconnectors/appsync/util/Await.java
+++ b/aws-android-sdk-appsync-tests/src/androidTest/java/com/amazonaws/mobileconnectors/appsync/util/Await.java
@@ -5,7 +5,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-package com.amazonaws.mobileconnectors.appsync;
+package com.amazonaws.mobileconnectors.appsync.util;
 
 import android.support.annotation.NonNull;
 
@@ -18,7 +18,7 @@ import java.util.concurrent.atomic.AtomicReference;
  * A utility to await a value from an async function, in a synchronous way.
  */
 @SuppressWarnings({"WeakerAccess", "SameParameterValue", "unused", "UnusedReturnValue"})
-final class Await {
+public final class Await {
     private static final long DEFAULT_WAIT_TIME_MS = TimeUnit.SECONDS.toMillis(10);
 
     private Await() {}
@@ -29,7 +29,7 @@ final class Await {
      * @param waitTimeMs Time in milliseconds to wait for count down before timing out with exception
      * @throws RuntimeException If the latch doesn't count down in the specified amount of time
      */
-    static void latch(CountDownLatch latch, long waitTimeMs) {
+    public static void latch(CountDownLatch latch, long waitTimeMs) {
         try {
             latch.await(waitTimeMs, TimeUnit.MILLISECONDS);
         } catch (InterruptedException interruptedException) {
@@ -47,7 +47,7 @@ final class Await {
      * @param latch A count down latch for which countdown is awaited
      * @throws RuntimeException If the latch doesn't count down in a reasonable amount of time
      */
-    static void latch(@NonNull CountDownLatch latch) {
+    public static void latch(@NonNull CountDownLatch latch) {
         latch(latch, DEFAULT_WAIT_TIME_MS);
     }
 
@@ -63,7 +63,7 @@ final class Await {
      * @throws RuntimeException In all other situations where there is not a non-null result
      */
     @NonNull
-    static <R, E extends Throwable> R result(
+    public static <R, E extends Throwable> R result(
         @NonNull ResultErrorEmitter<R, E> resultErrorEmitter) throws E {
         return result(DEFAULT_WAIT_TIME_MS, resultErrorEmitter);
     }
@@ -81,7 +81,7 @@ final class Await {
      * @throws RuntimeException In all other situations where there is not a non-null result
      */
     @NonNull
-    static <R, E extends Throwable> R result(
+    public static <R, E extends Throwable> R result(
         long timeMs, @NonNull ResultErrorEmitter<R, E> resultErrorEmitter) throws E {
 
         Objects.requireNonNull(resultErrorEmitter);
@@ -127,7 +127,7 @@ final class Await {
      * @throws RuntimeException If no error is emitted by the emitter
      */
     @NonNull
-    static <R, E extends Throwable> E error(
+    public static <R, E extends Throwable> E error(
             long timeMs, @NonNull ResultErrorEmitter<R, E> resultErrorEmitter) {
 
         Objects.requireNonNull(resultErrorEmitter);
@@ -183,7 +183,7 @@ final class Await {
      * @param <R> Type of result
      * @param <E> Type of error
      */
-    interface ResultErrorEmitter<R, E extends Throwable> {
+    public interface ResultErrorEmitter<R, E extends Throwable> {
         /**
          * A function that emits a value upon completion, either as a
          * result or as an error.

--- a/aws-android-sdk-appsync-tests/src/androidTest/java/com/amazonaws/mobileconnectors/appsync/util/Consumer.java
+++ b/aws-android-sdk-appsync-tests/src/androidTest/java/com/amazonaws/mobileconnectors/appsync/util/Consumer.java
@@ -5,7 +5,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-package com.amazonaws.mobileconnectors.appsync;
+package com.amazonaws.mobileconnectors.appsync.util;
 
 /**
  * A consumer of a value.
@@ -13,7 +13,7 @@ package com.amazonaws.mobileconnectors.appsync;
  * which is only available after API 24.
  * @param <V> The type of value being consumed
  */
-interface Consumer<V> {
+public interface Consumer<V> {
     /**
      * Accept a value.
      * @param value Value being consumed

--- a/aws-android-sdk-appsync-tests/src/androidTest/java/com/amazonaws/mobileconnectors/appsync/util/DataFile.java
+++ b/aws-android-sdk-appsync-tests/src/androidTest/java/com/amazonaws/mobileconnectors/appsync/util/DataFile.java
@@ -4,7 +4,7 @@
  * <p>
  * SPDX-License-Identifier: Apache-2.0
  */
-package com.amazonaws.mobileconnectors.appsync;
+package com.amazonaws.mobileconnectors.appsync.util;
 
 import android.content.Context;
 import android.support.annotation.NonNull;
@@ -14,7 +14,7 @@ import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
 
-final class DataFile {
+public final class DataFile {
     private DataFile() {}
 
     @NonNull

--- a/aws-android-sdk-appsync-tests/src/androidTest/java/com/amazonaws/mobileconnectors/appsync/util/JsonExtract.java
+++ b/aws-android-sdk-appsync-tests/src/androidTest/java/com/amazonaws/mobileconnectors/appsync/util/JsonExtract.java
@@ -5,17 +5,17 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-package com.amazonaws.mobileconnectors.appsync;
+package com.amazonaws.mobileconnectors.appsync.util;
 
 import org.json.JSONException;
 import org.json.JSONObject;
 
-final class JsonExtract {
+public final class JsonExtract {
     private JsonExtract() {}
 
     // This is a poor man's implementation of JSONPath, that just handles literals,
     // with the '.' meaning "down one more level." This will break if your key contains a period.
-    static String stringValue(JSONObject container, String path) {
+    public static String stringValue(JSONObject container, String path) {
         int indexOfFirstPeriod = path.indexOf(".");
         if (indexOfFirstPeriod != -1) {
             String firstPortion = path.substring(0, indexOfFirstPeriod);

--- a/aws-android-sdk-appsync-tests/src/androidTest/java/com/amazonaws/mobileconnectors/appsync/util/Sleep.java
+++ b/aws-android-sdk-appsync-tests/src/androidTest/java/com/amazonaws/mobileconnectors/appsync/util/Sleep.java
@@ -5,7 +5,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-package com.amazonaws.mobileconnectors.appsync;
+package com.amazonaws.mobileconnectors.appsync.util;
 
 import java.util.concurrent.TimeUnit;
 
@@ -14,7 +14,7 @@ import java.util.concurrent.TimeUnit;
  * The {@link InterruptedException} thrown by {@link Thread#sleep(long)} is wrapped into an
  * {@link RuntimeException} which helps cut down on test code clutter.
  */
-final class Sleep {
+public final class Sleep {
     private Sleep() {}
 
     /**
@@ -22,7 +22,7 @@ final class Sleep {
      * @param milliseconds Duration of time to sleep
      * @throws RuntimeException If unable to sleep for the requested amount of time
      */
-    static void milliseconds(long milliseconds) {
+    public static void milliseconds(long milliseconds) {
         try {
             Thread.sleep(milliseconds);
         } catch (InterruptedException interruptedException) {
@@ -35,7 +35,7 @@ final class Sleep {
      * @param seconds Duration of time to sleep
      * @throws RuntimeException If unable to sleep for the requested amount of time
      */
-    static void seconds(long seconds) {
+    public static void seconds(long seconds) {
         milliseconds(TimeUnit.SECONDS.toMillis(seconds));
     }
 }

--- a/aws-android-sdk-appsync-tests/src/androidTest/java/com/amazonaws/mobileconnectors/appsync/util/Wifi.java
+++ b/aws-android-sdk-appsync-tests/src/androidTest/java/com/amazonaws/mobileconnectors/appsync/util/Wifi.java
@@ -5,7 +5,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-package com.amazonaws.mobileconnectors.appsync;
+package com.amazonaws.mobileconnectors.appsync.util;
 
 import android.content.Context;
 import android.net.wifi.WifiManager;
@@ -15,14 +15,14 @@ import static android.support.test.InstrumentationRegistry.getTargetContext;
 import static org.junit.Assert.assertTrue;
 
 @SuppressWarnings("unused")
-final class Wifi {
+public final class Wifi {
     private Wifi() {}
 
-    static void turnOn() {
+    public static void turnOn() {
         assertTrue(wifiManager().setWifiEnabled(true));
     }
 
-    static void turnOff() {
+    public static void turnOff() {
         assertTrue(wifiManager().setWifiEnabled(false));
     }
 

--- a/aws-android-sdk-appsync-tests/src/androidTest/java/com/amazonaws/mobileconnectors/appsync/util/package-info.java
+++ b/aws-android-sdk-appsync-tests/src/androidTest/java/com/amazonaws/mobileconnectors/appsync/util/package-info.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2018-2020 Amazon.com,
+ * Inc. or its affiliates. All Rights Reserved.
+ * <p>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * This package contains generic utilities that ARE NOT part of the AppSync domain.
+ * Utilities that have AppSync concerns must find another home, or else this package
+ * will take on muddled concerns.
+ *
+ * {@link com.amazonaws.mobileconnectors.appsync.util.Await} is useful for converting
+ * async calls to sync.
+ *
+ * {@link com.amazonaws.mobileconnectors.appsync.util.Consumer} is a compat version of
+ * {@link java.util.function.Consumer}, which can be used without worrying about platform
+ * versions.
+ *
+ * {@link com.amazonaws.mobileconnectors.appsync.util.Sleep} is a wrapper around
+ * {@link java.lang.Thread#sleep(long)}, which reduces the boiler plate of use.
+ *
+ * {@link com.amazonaws.mobileconnectors.appsync.util.Wifi} is for turning on/off the
+ * test device's WiFi.
+ *
+ * {@link com.amazonaws.mobileconnectors.appsync.util.JsonExtract} and
+ * {@link com.amazonaws.mobileconnectors.appsync.util.DataFile} are string/file manipulation
+ * utilities.
+ */
+package com.amazonaws.mobileconnectors.appsync.util;


### PR DESCRIPTION
The last few commits blew apart the integration tests into many smaller
pieces. This created a single Java package with lots of loosely coupled
classes.

To make the code more navigable, some packaging is introduced, to group
together classes which serve related functionalities.

The tests have been renamed _without_ AWSAppSync in the front -- if you're
hear reading this, well, friend, that should be clear!

By submitting this pull request, I confirm that you can use, modify, copy,
and redistribute this contribution, under the terms of your choice.
