### PR TITLE
Client prefix not honored when passed programmatically

### DIFF
--- a/aws-android-sdk-appsync/src/main/java/com/amazonaws/mobileconnectors/appsync/AWSAppSyncClient.java
+++ b/aws-android-sdk-appsync/src/main/java/com/amazonaws/mobileconnectors/appsync/AWSAppSyncClient.java
@@ -554,7 +554,7 @@ public class AWSAppSyncClient {
                     mServerUrl = mServerUrl != null ? mServerUrl : appSyncJsonObject.getString("ApiUrl");
                     mRegion = mRegion != null ? mRegion : Regions.fromName(appSyncJsonObject.getString("Region"));
 
-                    if (mUseClientDatabasePrefix) {
+                    if (mUseClientDatabasePrefix && mClientDatabasePrefix == null) {
                         // Populate the ClientDatabasePrefix from awsconfiguration.json
                         String clientDatabasePrefixFromConfigJson = null;
                         try {

--- a/aws-android-sdk-appsync/src/test/java/com/amazonaws/mobileconnectors/appsync/AppSyncClientUnitTest.java
+++ b/aws-android-sdk-appsync/src/test/java/com/amazonaws/mobileconnectors/appsync/AppSyncClientUnitTest.java
@@ -39,6 +39,7 @@ import javax.annotation.Nonnull;
 
 import static junit.framework.TestCase.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
@@ -142,14 +143,28 @@ public class AppSyncClientUnitTest {
     public void testClientDatabasePrefixFromBuilder() {
         String prefix = "prefix_from_builder";
         awsConfiguration.setConfiguration("Default");
+        // Create an instance with useClientDatabasePrefix = true
         final AWSAppSyncClient awsAppSyncClient = AWSAppSyncClient.builder()
                                                                   .context(shadowContext)
                                                                   .clientDatabasePrefix(prefix)
                                                                   .useClientDatabasePrefix(true)
                                                                   .awsConfiguration(awsConfiguration)
                                                                   .build();
+
+        // Create an instance with useClientDatabasePrefix = false
+        final AWSAppSyncClient awsAppSyncClientWithoutPrefix = AWSAppSyncClient.builder()
+                                                                  .context(shadowContext)
+                                                                  .clientDatabasePrefix(prefix)
+                                                                  .useClientDatabasePrefix(false)
+                                                                  .awsConfiguration(awsConfiguration)
+                                                                  .build();
+        // Verify that prefix is set.
         assertNotNull(awsAppSyncClient);
         assertEquals(prefix, awsAppSyncClient.clientDatabasePrefix);
+
+        // Verify prefix is not set.
+        assertNotNull(awsAppSyncClientWithoutPrefix);
+        assertNull(awsAppSyncClientWithoutPrefix.clientDatabasePrefix);
     }
 
     @Test

--- a/aws-android-sdk-appsync/src/test/java/com/amazonaws/mobileconnectors/appsync/AppSyncClientUnitTest.java
+++ b/aws-android-sdk-appsync/src/test/java/com/amazonaws/mobileconnectors/appsync/AppSyncClientUnitTest.java
@@ -20,6 +20,8 @@ import com.apollographql.apollo.internal.RealAppSyncCall;
 import com.apollographql.apollo.internal.RealAppSyncSubscriptionCall;
 import com.apollographql.apollo.internal.subscription.SubscriptionManager;
 
+import org.json.JSONException;
+import org.json.JSONObject;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -102,7 +104,8 @@ public class AppSyncClientUnitTest {
                 "      \"ApiUrl\": \"https://xxxx.appsync-api.us-east-1.amazonaws.com/graphql\",\n" +
                 "      \"Region\": \"us-east-1\",\n" +
                 "      \"ApiKey\": \"da2-xxxx\",\n" +
-                "      \"AuthMode\": \"API_KEY\"\n" +
+                "      \"AuthMode\": \"API_KEY\",\n" +
+                "      \"ClientDatabasePrefix\": \"prefix_from_config\"\n" +
                 "    },\n" +
                 "    \"AwsIam\": {\n" +
                 "      \"ApiUrl\": \"https://xxxx.appsync-api.us-east-1.amazonaws.com/graphql\",\n" +
@@ -133,6 +136,34 @@ public class AppSyncClientUnitTest {
                 .awsConfiguration(awsConfiguration)
                 .build();
         assertNotNull(awsAppSyncClient);
+    }
+
+    @Test
+    public void testClientDatabasePrefixFromBuilder() {
+        String prefix = "prefix_from_builder";
+        awsConfiguration.setConfiguration("Default");
+        final AWSAppSyncClient awsAppSyncClient = AWSAppSyncClient.builder()
+                                                                  .context(shadowContext)
+                                                                  .clientDatabasePrefix(prefix)
+                                                                  .useClientDatabasePrefix(true)
+                                                                  .awsConfiguration(awsConfiguration)
+                                                                  .build();
+        assertNotNull(awsAppSyncClient);
+        assertEquals(prefix, awsAppSyncClient.clientDatabasePrefix);
+    }
+
+    @Test
+    public void testClientDatabasePrefixFromConfig() throws JSONException {
+        awsConfiguration.setConfiguration("ApiKey");
+        JSONObject appSyncJsonObject = awsConfiguration.optJsonObject("AppSync");
+        String prefix = appSyncJsonObject.getString("ClientDatabasePrefix");
+        final AWSAppSyncClient awsAppSyncClient = AWSAppSyncClient.builder()
+                                                                  .context(shadowContext)
+                                                                  .useClientDatabasePrefix(true)
+                                                                  .awsConfiguration(awsConfiguration)
+                                                                  .build();
+        assertNotNull(awsAppSyncClient);
+        assertEquals(prefix, awsAppSyncClient.clientDatabasePrefix);
     }
 
     @Test


### PR DESCRIPTION
*Issue #, if available:*
#306 

*Description of changes:*
Client database prefix setting was not being honored when passed in programmatically. This PR resolves that issue by using checking if the prefix is set programmatically before trying to use one from the config file.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
