### PR TITLE
Implement auto reconnect for WebSocketConnectionManager

### DIFF
--- a/aws-android-sdk-appsync/src/main/java/com/amazonaws/mobileconnectors/appsync/AWSAppSyncClient.java
+++ b/aws-android-sdk-appsync/src/main/java/com/amazonaws/mobileconnectors/appsync/AWSAppSyncClient.java
@@ -261,7 +261,9 @@ public class AWSAppSyncClient {
 
         SubscriptionAuthorizer subscriptionAuthorizer = new SubscriptionAuthorizer(builder);
 
-        webSocketConnectionManager = new WebSocketConnectionManager(builder.mServerUrl,
+        webSocketConnectionManager = new WebSocketConnectionManager(
+            applicationContext,
+            builder.mServerUrl,
             subscriptionAuthorizer,
             new ApolloResponseBuilder(builder.customTypeAdapters, mApolloClient.apolloStore().networkResponseNormalizer()),
             builder.mSubscriptionsAutoReconnect);

--- a/aws-android-sdk-appsync/src/main/java/com/amazonaws/mobileconnectors/appsync/AWSAppSyncClient.java
+++ b/aws-android-sdk-appsync/src/main/java/com/amazonaws/mobileconnectors/appsync/AWSAppSyncClient.java
@@ -263,7 +263,8 @@ public class AWSAppSyncClient {
 
         webSocketConnectionManager = new WebSocketConnectionManager(builder.mServerUrl,
             subscriptionAuthorizer,
-            new ApolloResponseBuilder(builder.customTypeAdapters, mApolloClient.apolloStore().networkResponseNormalizer()));
+            new ApolloResponseBuilder(builder.customTypeAdapters, mApolloClient.apolloStore().networkResponseNormalizer()),
+            builder.mSubscriptionsAutoReconnect);
     }
 
     /**

--- a/aws-android-sdk-appsync/src/main/java/com/amazonaws/mobileconnectors/appsync/ConnectivityWatcher.java
+++ b/aws-android-sdk-appsync/src/main/java/com/amazonaws/mobileconnectors/appsync/ConnectivityWatcher.java
@@ -1,0 +1,124 @@
+package com.amazonaws.mobileconnectors.appsync;
+
+import android.content.BroadcastReceiver;
+import android.content.Context;
+import android.content.Intent;
+import android.content.IntentFilter;
+import android.net.ConnectivityManager;
+import android.net.Network;
+import android.net.NetworkInfo;
+import android.net.NetworkRequest;
+import android.os.Build;
+import android.support.annotation.RequiresApi;
+
+class ConnectivityWatcher {
+
+    interface Callback {
+        void onConnectivityChanged(boolean isNetworkConnected);
+    }
+
+    private final Context context;
+    private final Callback callback;
+    private final ConnectivityManager connManager;
+    private BroadcastReceiver broadcastReceiver;
+    private ConnectivityManager.NetworkCallback networkCallback;
+
+    ConnectivityWatcher(Context context, Callback callback) {
+        this.context = context.getApplicationContext();
+        this.callback = callback;
+        this.connManager = (ConnectivityManager) context
+                .getSystemService(Context.CONNECTIVITY_SERVICE);
+    }
+
+    void register() {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
+            registerNetworkCallback();
+        } else {
+            registerBroadcastReceiver();
+        }
+    }
+
+    void unregister() {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
+            unregisterNetworkCallback();
+        } else {
+            unregisterBroadcastReceiver();
+        }
+    }
+
+    private void registerBroadcastReceiver() {
+        if (broadcastReceiver == null) {
+            broadcastReceiver = new ConnectivityChangeReceiver();
+            context.registerReceiver(broadcastReceiver, new IntentFilter(
+                    ConnectivityManager.CONNECTIVITY_ACTION));
+        }
+    }
+
+    private void unregisterBroadcastReceiver() {
+        if (broadcastReceiver != null) {
+            context.unregisterReceiver(broadcastReceiver);
+            broadcastReceiver = null;
+        }
+    }
+
+    @RequiresApi(Build.VERSION_CODES.LOLLIPOP)
+    private void registerNetworkCallback() {
+        if (networkCallback == null) {
+            networkCallback = new NetworkCallback();
+            connManager.registerNetworkCallback(
+                    new NetworkRequest.Builder().build(), networkCallback);
+        }
+    }
+
+    @RequiresApi(Build.VERSION_CODES.LOLLIPOP)
+    private void unregisterNetworkCallback() {
+        if (networkCallback != null) {
+            connManager.unregisterNetworkCallback(networkCallback);
+            networkCallback = null;
+        }
+    }
+
+    /**
+     * Gets the status of network connectivity.
+     *
+     * @return true if network is connected, false otherwise.
+     */
+    private boolean isNetworkConnected() {
+        final NetworkInfo info = connManager.getActiveNetworkInfo();
+        return info != null && info.isConnected();
+    }
+
+    private class ConnectivityChangeReceiver extends BroadcastReceiver {
+        @Override
+        public void onReceive(Context context, Intent intent) {
+            if (ConnectivityManager.CONNECTIVITY_ACTION.equals(intent.getAction())) {
+                callback.onConnectivityChanged(isNetworkConnected());
+            }
+        }
+
+    }
+
+    @RequiresApi(Build.VERSION_CODES.LOLLIPOP)
+    private class NetworkCallback extends ConnectivityManager.NetworkCallback {
+        private boolean isConnected = isNetworkConnected();
+
+        private void checkConnected() {
+            boolean isConnectedNow = isNetworkConnected();
+            if (isConnected != isConnectedNow) {
+                isConnected = isConnectedNow;
+                callback.onConnectivityChanged(isConnectedNow);
+            }
+        }
+
+        @Override
+        public void onAvailable(Network network) {
+            checkConnected();
+        }
+
+        @Override
+        public void onLost(Network network) {
+            checkConnected();
+        }
+    }
+
+}

--- a/aws-android-sdk-appsync/src/main/java/com/amazonaws/mobileconnectors/appsync/WebSocketConnectionManager.java
+++ b/aws-android-sdk-appsync/src/main/java/com/amazonaws/mobileconnectors/appsync/WebSocketConnectionManager.java
@@ -16,6 +16,7 @@ import android.support.annotation.NonNull;
 import android.util.Base64;
 import android.util.Log;
 
+import com.amazonaws.AmazonClientException;
 import com.amazonaws.mobileconnectors.appsync.retry.RetryInterceptor;
 import com.apollographql.apollo.api.Operation;
 import com.apollographql.apollo.api.Subscription;
@@ -296,7 +297,15 @@ final class WebSocketConnectionManager {
         if (websocket != null) {
             websocket.cancel();
         }
-        createWebSocket();
+
+        try {
+            createWebSocket();
+        } catch (AmazonClientException e) {
+            Log.v(TAG, "Failed to create WebSocket: " + e);
+            scheduleReconnect();
+            return;
+        }
+
         for (Map.Entry<String, SubscriptionResponseDispatcher<?, ?, ?>> entry : subscriptions.entrySet()) {
             SubscriptionResponseDispatcher<?, ?, ?> dispatcher = entry.getValue();
             startSubscription(dispatcher.getSubscription(), dispatcher.getCallback(), entry.getKey());


### PR DESCRIPTION
*Issue #, if available:* #317

*Description of changes:*
Implemented auto reconnect for WebSocket-based subscriptions in WebSocketConnectionManager based on legacy implementation in [`RealSubscriptionManager`](../blob/198913897c36b6e26e3662bb7301e1a8024f424c/aws-android-sdk-appsync/src/main/java/com/amazonaws/mobileconnectors/appsync/subscription/RealSubscriptionManager.java#L410).
Also added result check for [`WebSocket.send()`](https://square.github.io/okhttp/4.x/okhttp/okhttp3/-web-socket/send/). This fixes the bug that further subscriptions after the `WebSocketListener`'s `onFailure` callback will fail silently because once failed `WebSocket`s cannot be used any more.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
