### PR TITLE
fix: use HTTPS endpoint for Github repo

### DIFF
--- a/build-support/fastlane/Fastfile
+++ b/build-support/fastlane/Fastfile
@@ -1,7 +1,7 @@
 default_platform(:android)
 
 import_from_git(
-    url: 'git@github.com:aws-amplify/amplify-ci-support.git',
+    url: 'https://github.com/aws-amplify/amplify-ci-support',
     branch: 'android/fastlane-actions',
     path: './src/fastlane/release_actions/fastlane/AndroidAppsFastfile'
 )


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Use the HTTPS endpoint to import the shared lane from amplify-ci-support

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
