### PR TITLE
fix(build): add signing options for automation

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -26,6 +26,19 @@ allprojects {
     }
 }
 
+subprojects { project ->
+    afterEvaluate {
+        if (System.getenv("ORG_GRADLE_PROJECT_signingKeyId") != null) {
+            System.out.println("Getting signing info from protected source.")
+            project.ext.'signing.keyId' = System.getenv("ORG_GRADLE_PROJECT_signingKeyId")
+            project.ext.'signing.password' = System.getenv('ORG_GRADLE_PROJECT_signingPassword')
+            project.ext.'signing.inMemoryKey' = System.getenv('ORG_GRADLE_PROJECT_signingInMemoryKey')
+            project.ext.SONATYPE_NEXUS_USERNAME =  System.getenv('ORG_GRADLE_PROJECT_SONATYPE_NEXUS_USERNAME')
+            project.ext.SONATYPE_NEXUS_PASSWORD = System.getenv('ORG_GRADLE_PROJECT_SONATYPE_NEXUS_PASSWORD')
+        }
+    }
+}
+
 task clean(type: Delete) {
     delete rootProject.buildDir
 }

--- a/gradle-mvn-push.gradle
+++ b/gradle-mvn-push.gradle
@@ -105,6 +105,11 @@ afterEvaluate { project ->
 
   signing {
     required { isReleaseBuild() && gradle.taskGraph.hasTask("uploadArchives") }
+    if (project.hasProperty('signing.inMemoryKey')) {
+      def signingKey = findProperty("signing.inMemoryKey").replace("\\n","\n")
+      def signingPassword = findProperty("signing.password")
+      useInMemoryPgpKeys(signingKey, signingPassword)
+    }
     sign configurations.archives
   }
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Neglected to add the bits to allow the signing and publishing process to work within the automation framework we're using. That framework uses environment variables prefixed with `ORG_GRADLE_PROJECT_` to set gradle project properties used during the deployment process (i.e. `signing.*` and `NEXUS*`). That allows us to avoid passing that information through config files or command line parameters.

In order to fix this, I needed to add changes similar to the ones made in `amplify-android` gradle files. Unfortunately, the version of gradle used in this repo does not automatically interpret environment variables prefixed with `ORG_GRADLE_PROJECT_` as gradle project properties.

As a result, the implementation I came up with for this repo is a bit different. It has to read the `ORG_GRADLE_PROJECT_` environment variables manually. A little ugly, but not a huge deal.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
