### PR TITLE
feat: add support for AWS_LAMBDA auth mode

### DIFF
--- a/aws-android-sdk-appsync/src/main/java/com/amazonaws/mobileconnectors/appsync/AWSAppSyncClient.java
+++ b/aws-android-sdk-appsync/src/main/java/com/amazonaws/mobileconnectors/appsync/AWSAppSyncClient.java
@@ -19,6 +19,7 @@ import com.amazonaws.mobileconnectors.appsync.cache.normalized.sql.AppSyncSqlHel
 import com.amazonaws.mobileconnectors.appsync.fetcher.AppSyncResponseFetchers;
 import com.amazonaws.mobileconnectors.appsync.retry.RetryInterceptor;
 import com.amazonaws.mobileconnectors.appsync.sigv4.APIKeyAuthProvider;
+import com.amazonaws.mobileconnectors.appsync.sigv4.AWSLambdaAuthProvider;
 import com.amazonaws.mobileconnectors.appsync.sigv4.AppSyncSigV4SignerInterceptor;
 import com.amazonaws.mobileconnectors.appsync.sigv4.BasicAPIKeyAuthProvider;
 import com.amazonaws.mobileconnectors.appsync.sigv4.CognitoUserPoolsAuthProvider;
@@ -105,7 +106,8 @@ public class AWSAppSyncClient {
         API_KEY("API_KEY"),
         AWS_IAM("AWS_IAM"),
         AMAZON_COGNITO_USER_POOLS("AMAZON_COGNITO_USER_POOLS"),
-        OPENID_CONNECT("OPENID_CONNECT");
+        OPENID_CONNECT("OPENID_CONNECT"),
+        AWS_LAMBDA("AWS_LAMBDA");
 
         private final String name;
 
@@ -159,6 +161,8 @@ public class AWSAppSyncClient {
             appSyncSigV4SignerInterceptor = new AppSyncSigV4SignerInterceptor(builder.mCognitoUserPoolsAuthProvider, builder.mRegion.getName());
         } else if (builder.mOidcAuthProvider != null) {
             appSyncSigV4SignerInterceptor = new AppSyncSigV4SignerInterceptor(builder.mOidcAuthProvider);
+        } else if (builder.mAWSLambdaAuthProvider != null) {
+            appSyncSigV4SignerInterceptor = new AppSyncSigV4SignerInterceptor(builder.mAWSLambdaAuthProvider);
         } else if (builder.mApiKey != null) {
             appSyncSigV4SignerInterceptor = new AppSyncSigV4SignerInterceptor(builder.mApiKey, builder.mRegion.getName(),  getClientSubscriptionUUID(builder.mApiKey.getAPIKey()));
         } else {
@@ -309,6 +313,7 @@ public class AWSAppSyncClient {
         APIKeyAuthProvider mApiKey;
         CognitoUserPoolsAuthProvider mCognitoUserPoolsAuthProvider;
         OidcAuthProvider mOidcAuthProvider;
+        AWSLambdaAuthProvider mAWSLambdaAuthProvider;
         NormalizedCacheFactory mNormalizedCacheFactory;
         CacheKeyResolver mResolver;
         ConflictResolverInterface mConflictResolver;
@@ -362,6 +367,11 @@ public class AWSAppSyncClient {
 
         public Builder oidcAuthProvider(OidcAuthProvider oidcAuthProvider) {
             mOidcAuthProvider = oidcAuthProvider;
+            return this;
+        }
+
+        public Builder awsLamdbaAuthProvider(AWSLambdaAuthProvider awsLambdaAuthProvider) {
+            mAWSLambdaAuthProvider = awsLambdaAuthProvider;
             return this;
         }
 
@@ -525,6 +535,7 @@ public class AWSAppSyncClient {
             authModeObjects.put(mCredentialsProvider, AuthMode.AWS_IAM);
             authModeObjects.put(mCognitoUserPoolsAuthProvider, AuthMode.AMAZON_COGNITO_USER_POOLS);
             authModeObjects.put(mOidcAuthProvider, AuthMode.OPENID_CONNECT);
+            authModeObjects.put(mAWSLambdaAuthProvider, AuthMode.AWS_LAMBDA);
             authModeObjects.remove(null);
 
             // Validate if only one Auth object is passed in to the builder

--- a/aws-android-sdk-appsync/src/main/java/com/amazonaws/mobileconnectors/appsync/sigv4/AWSLambdaAuthProvider.java
+++ b/aws-android-sdk-appsync/src/main/java/com/amazonaws/mobileconnectors/appsync/sigv4/AWSLambdaAuthProvider.java
@@ -1,0 +1,5 @@
+package com.amazonaws.mobileconnectors.appsync.sigv4;
+
+public interface AWSLambdaAuthProvider {
+    public String getLatestAuthToken();
+}

--- a/aws-android-sdk-appsync/src/main/java/com/amazonaws/mobileconnectors/appsync/sigv4/AppSyncSigV4SignerInterceptor.java
+++ b/aws-android-sdk-appsync/src/main/java/com/amazonaws/mobileconnectors/appsync/sigv4/AppSyncSigV4SignerInterceptor.java
@@ -45,6 +45,7 @@ public class AppSyncSigV4SignerInterceptor implements Interceptor {
 
     private final CognitoUserPoolsAuthProvider cognitoUserPoolsAuthProvider;
     private final OidcAuthProvider oidcAuthProvider;
+    private final AWSLambdaAuthProvider awsLambdaAuthProvider;
     private final String awsRegion;
     private final AuthMode authMode;
 
@@ -52,7 +53,8 @@ public class AppSyncSigV4SignerInterceptor implements Interceptor {
         API_KEY,
         IAM,
         OIDC_AUTHORIZATION_TOKEN,
-        USERPOOLS_AUTHORIZATION_TOKEN
+        USERPOOLS_AUTHORIZATION_TOKEN,
+        AWS_LAMBDA_AUTHORIZATION_TOKEN
     }
 
     public AppSyncSigV4SignerInterceptor(APIKeyAuthProvider apiKey, final String awsRegion, final String subscriberUUID){
@@ -61,6 +63,7 @@ public class AppSyncSigV4SignerInterceptor implements Interceptor {
         this.credentialsProvider = null;
         this.cognitoUserPoolsAuthProvider = null;
         this.oidcAuthProvider = null;
+        this.awsLambdaAuthProvider = null;
         authMode = AuthMode.API_KEY;
         this.subscriberUUID = subscriberUUID;
     }
@@ -71,6 +74,7 @@ public class AppSyncSigV4SignerInterceptor implements Interceptor {
         this.apiKey = null;
         this.cognitoUserPoolsAuthProvider = null;
         this.oidcAuthProvider = null;
+        this.awsLambdaAuthProvider = null;
         authMode = AuthMode.IAM;
         subscriberUUID = null;
     }
@@ -81,6 +85,7 @@ public class AppSyncSigV4SignerInterceptor implements Interceptor {
         this.apiKey = null;
         this.cognitoUserPoolsAuthProvider = cognitoUserPoolsAuthProvider;
         this.oidcAuthProvider = null;
+        this.awsLambdaAuthProvider = null;
         authMode = AuthMode.USERPOOLS_AUTHORIZATION_TOKEN;
         subscriberUUID = null;
     }
@@ -91,7 +96,19 @@ public class AppSyncSigV4SignerInterceptor implements Interceptor {
         this.apiKey = null;
         this.cognitoUserPoolsAuthProvider = null;
         this.oidcAuthProvider = oidcAuthProvider;
+        this.awsLambdaAuthProvider = null;
         authMode = AuthMode.OIDC_AUTHORIZATION_TOKEN;
+        subscriberUUID = null;
+    }
+
+    public AppSyncSigV4SignerInterceptor(AWSLambdaAuthProvider awsLambdaAuthProvider) {
+        this.credentialsProvider = null;
+        this.awsRegion = null;
+        this.apiKey = null;
+        this.cognitoUserPoolsAuthProvider = null;
+        this.oidcAuthProvider = null;
+        this.awsLambdaAuthProvider = awsLambdaAuthProvider;
+        authMode = AuthMode.AWS_LAMBDA_AUTHORIZATION_TOKEN;
         subscriberUUID = null;
     }
 
@@ -153,6 +170,13 @@ public class AppSyncSigV4SignerInterceptor implements Interceptor {
                 dr.addHeader(AUTHORIZATION, oidcAuthProvider.getLatestAuthToken());
             } catch (Exception e) {
                 IOException ioe = new IOException("Failed to retrieve OIDC token.", e);
+                throw ioe;
+            }
+        } else if (AuthMode.AWS_LAMBDA_AUTHORIZATION_TOKEN.equals(authMode)) {
+            try {
+                dr.addHeader(AUTHORIZATION, awsLambdaAuthProvider.getLatestAuthToken());
+            } catch (Exception e) {
+                IOException ioe = new IOException("Failed to retrieve AWS Lambda authorization token.", e);
                 throw ioe;
             }
         }

--- a/aws-android-sdk-appsync/src/test/java/com/amazonaws/mobileconnectors/appsync/AppSyncClientUnitTest.java
+++ b/aws-android-sdk-appsync/src/test/java/com/amazonaws/mobileconnectors/appsync/AppSyncClientUnitTest.java
@@ -6,6 +6,7 @@ import android.content.res.Resources;
 import com.amazonaws.auth.CognitoCredentialsProvider;
 import com.amazonaws.mobile.config.AWSConfiguration;
 import com.amazonaws.mobileconnectors.appsync.sigv4.APIKeyAuthProvider;
+import com.amazonaws.mobileconnectors.appsync.sigv4.AWSLambdaAuthProvider;
 import com.amazonaws.mobileconnectors.appsync.sigv4.BasicAPIKeyAuthProvider;
 import com.amazonaws.mobileconnectors.appsync.sigv4.BasicCognitoUserPoolsAuthProvider;
 import com.amazonaws.mobileconnectors.appsync.sigv4.OidcAuthProvider;
@@ -19,7 +20,6 @@ import com.apollographql.apollo.internal.ApolloLogger;
 import com.apollographql.apollo.internal.RealAppSyncCall;
 import com.apollographql.apollo.internal.RealAppSyncSubscriptionCall;
 import com.apollographql.apollo.internal.subscription.SubscriptionManager;
-
 import org.json.JSONException;
 import org.json.JSONObject;
 import org.junit.Before;
@@ -29,12 +29,10 @@ import org.mockito.Mockito;
 import org.robolectric.RobolectricTestRunner;
 import org.robolectric.RuntimeEnvironment;
 import org.robolectric.annotation.Config;
-import org.robolectric.shadows.ShadowApplication;
 
 import java.io.ByteArrayInputStream;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
-
 import javax.annotation.Nonnull;
 
 import static junit.framework.TestCase.assertEquals;
@@ -227,6 +225,22 @@ public class AppSyncClientUnitTest {
                     @Override
                     public String getLatestAuthToken() {
                         return null;
+                    }
+                })
+                .build();
+        assertNotNull(awsAppSyncClient);
+    }
+
+    @Test
+    public void testAWSLambdaAuthProvider() {
+        awsConfiguration.setConfiguration("OpenidConnect");
+        final AWSAppSyncClient awsAppSyncClient = AWSAppSyncClient.builder()
+                .context(shadowContext)
+                .awsConfiguration(awsConfiguration)
+                .awsLamdbaAuthProvider(new AWSLambdaAuthProvider() {
+                    @Override
+                    public String getLatestAuthToken() {
+                        return "AWS_LAMBDA_AUTHORIZATION_TOKEN";
                     }
                 })
                 .build();


### PR DESCRIPTION
Today, [AppSync supports four authorization types](https://docs.aws.amazon.com/appsync/latest/devguide/security-authz.html) - `API_KEY`, `AWS_IAM`, `OPENID_CONNECT`, and `AMAZON_COGNITO_USER_POOLS`.    This PR adds support for a 5th type: `AWS_LAMBDA`.  Customers will be able to create their own AWS Lambda function, which will determine whether to authorize each request based on an authorization token that the customer provides to Amplify.
 
The developer experience is very similar to `OPENID_CONNECT`.  Today, customers can provide their own OIDC token to Amplify by implementing an `OIDCTokenProvider`, and providing it to the `AWSApiPlugin` like this:

```
mAWSAppSyncClient = AWSAppSyncClient.builder()
    .context(getApplicationContext())
    .awsConfiguration(new AWSConfiguration(getApplicationContext()))
   .oidcAuthProvider(() -> "MyOidcAuthToken")
    .build();
```

For AWS Lambda custom auth, developers can provide their own token by implementing a `CustomAuthProvider` like this:

```
mAWSAppSyncClient = AWSAppSyncClient.builder()
    .context(getApplicationContext())
    .awsConfiguration(new AWSConfiguration(getApplicationContext()))
    .awsLambdaAuthProvider(() -> "MyAwsLambdaAuthToken")
    .build();
```
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
