### PR TITLE
Add support for Gradle 7 projects

### DIFF
--- a/aws-android-sdk-appsync-gradle-plugin/src/main/java/com/apollographql/apollo/gradle/ApolloIRGenTask.java
+++ b/aws-android-sdk-appsync-gradle-plugin/src/main/java/com/apollographql/apollo/gradle/ApolloIRGenTask.java
@@ -253,4 +253,28 @@ public class ApolloIRGenTask extends NodeTask {
   public File getOutputFolder() {
     return outputFolder;
   }
+
+  public String getVariant() {
+    return variant;
+  }
+
+  public void setVariant(String variant) {
+    this.variant = variant;
+  }
+
+  public ImmutableList<String> getSourceSets() {
+    return sourceSets;
+  }
+
+  public void setSourceSets(ImmutableList<String> sourceSets) {
+    this.sourceSets = sourceSets;
+  }
+
+  public ApolloExtension getExtension() {
+    return extension;
+  }
+
+  public void setExtension(ApolloExtension extension) {
+    this.extension = extension;
+  }
 }


### PR DESCRIPTION
*Issue #, if available:*
#360 

*Description of changes:*
Task
---
In Gradle 7, build fails because private fields are annotated with `@Internal` but don't have any getters.

Solution
---
Add getters and setters to the fields marked with `@Internal`.
This is consistent with other fields marked as `@Internal` in `ApolloClassGenTask`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
