### PR TITLE
Migrate project to AndroidX libraries

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -25,11 +25,12 @@ android {
 }
 
 dependencies {
-    implementation 'com.android.support:appcompat-v7:28.0.0'
-    implementation 'com.android.support:support-compat:28.0.0'
-    implementation 'com.android.support:recyclerview-v7:28.0.0'
-    implementation 'com.android.support:design:28.0.0'
-    implementation 'com.android.support.constraint:constraint-layout:1.1.3'
+    implementation 'androidx.appcompat:appcompat:1.0.0'
+    implementation 'androidx.core:core:1.0.0'
+    implementation 'androidx.recyclerview:recyclerview:1.0.0'
+    implementation 'com.google.android.material:material:1.0.0'
+    implementation 'androidx.constraintlayout:constraintlayout:1.1.3'
+    implementation 'androidx.swiperefreshlayout:swiperefreshlayout:1.0.0'
 
     implementation project(':aws-android-sdk-appsync-runtime')
     implementation project(':aws-android-sdk-appsync-api')
@@ -40,8 +41,8 @@ dependencies {
     implementation "com.amazonaws:aws-android-sdk-core:$aws_version"
     implementation "com.amazonaws:aws-android-sdk-s3:$aws_version"
 
-    def lifecycle_version = "1.1.1"
-    implementation("android.arch.lifecycle:runtime:$lifecycle_version")
-    implementation("android.arch.lifecycle:extensions:$lifecycle_version")
+    def lifecycle_version = "2.0.0"
+    implementation("androidx.lifecycle:lifecycle-runtime:$lifecycle_version")
+    implementation("androidx.lifecycle:lifecycle-extensions:$lifecycle_version")
 }
 

--- a/app/src/main/java/com/amazonaws/postsapp/AddPostActivity.java
+++ b/app/src/main/java/com/amazonaws/postsapp/AddPostActivity.java
@@ -3,7 +3,7 @@ package com.amazonaws.postsapp;
 import android.content.Context;
 import android.content.Intent;
 import android.os.Bundle;
-import android.support.v7.app.AppCompatActivity;
+import androidx.appcompat.app.AppCompatActivity;
 import android.util.Log;
 import android.view.Menu;
 import android.view.MenuItem;
@@ -12,15 +12,9 @@ import android.widget.Toast;
 
 import com.amazonaws.amplify.generated.graphql.CreatePostMutation;
 import com.amazonaws.mobileconnectors.appsync.AWSAppSyncClient;
-import com.amazonaws.mobileconnectors.appsync.fetcher.AppSyncResponseFetchers;
 import com.apollographql.apollo.GraphQLCall;
 import com.apollographql.apollo.api.Response;
-import com.apollographql.apollo.cache.normalized.CacheKey;
 import com.apollographql.apollo.exception.ApolloException;
-
-import java.util.ArrayList;
-import java.util.List;
-import java.util.UUID;
 
 import javax.annotation.Nonnull;
 

--- a/app/src/main/java/com/amazonaws/postsapp/PostsActivity.java
+++ b/app/src/main/java/com/amazonaws/postsapp/PostsActivity.java
@@ -1,18 +1,18 @@
 package com.amazonaws.postsapp;
 
 import android.os.Bundle;
-import android.support.design.widget.FloatingActionButton;
-import android.support.v4.widget.SwipeRefreshLayout;
-import android.support.v7.app.AppCompatActivity;
-import android.support.v7.widget.LinearLayoutManager;
-import android.support.v7.widget.RecyclerView;
-import android.util.Log;
+import androidx.appcompat.app.AppCompatActivity;
+
 import android.view.View;
-import android.arch.lifecycle.ProcessLifecycleOwner;
+import androidx.lifecycle.ProcessLifecycleOwner;
+import androidx.recyclerview.widget.LinearLayoutManager;
+import androidx.recyclerview.widget.RecyclerView;
+import androidx.swiperefreshlayout.widget.SwipeRefreshLayout;
 
 
 import com.amazonaws.mobileconnectors.appsync.AWSAppSyncAppLifecycleObserver;
 import com.amazonaws.mobileconnectors.appsync.AWSAppSyncClient;
+import com.google.android.material.floatingactionbutton.FloatingActionButton;
 
 public class PostsActivity extends AppCompatActivity {
     private static final String TAG = PostsActivity.class.getSimpleName();

--- a/app/src/main/java/com/amazonaws/postsapp/PostsAdapter.java
+++ b/app/src/main/java/com/amazonaws/postsapp/PostsAdapter.java
@@ -1,6 +1,5 @@
 package com.amazonaws.postsapp;
 
-import android.support.v7.widget.RecyclerView;
 import android.util.Log;
 import android.view.LayoutInflater;
 import android.view.View;
@@ -8,11 +7,11 @@ import android.view.ViewGroup;
 import android.widget.TextView;
 import android.widget.Toast;
 
+import androidx.recyclerview.widget.RecyclerView;
 
 import com.amazonaws.amplify.generated.graphql.DeletePostMutation;
 import com.amazonaws.amplify.generated.graphql.ListPostsDeltaQuery;
 import com.amazonaws.amplify.generated.graphql.ListPostsQuery;
-
 import com.amazonaws.amplify.generated.graphql.OnDeltaPostSubscription;
 import com.amazonaws.amplify.generated.graphql.UpdatePostMutation;
 import com.amazonaws.mobileconnectors.appsync.AWSAppSyncClient;

--- a/app/src/main/java/com/amazonaws/postsapp/UpdatePostActivity.java
+++ b/app/src/main/java/com/amazonaws/postsapp/UpdatePostActivity.java
@@ -3,20 +3,14 @@ package com.amazonaws.postsapp;
 import android.content.Context;
 import android.content.Intent;
 import android.os.Bundle;
-import android.support.v7.app.AppCompatActivity;
-import android.util.Log;
+import androidx.appcompat.app.AppCompatActivity;
+
 import android.view.Menu;
 import android.view.MenuItem;
 import android.widget.EditText;
-import android.widget.Toast;
 
 
 import com.amazonaws.amplify.generated.graphql.ListPostsQuery;
-import com.apollographql.apollo.GraphQLCall;
-import com.apollographql.apollo.api.Response;
-import com.apollographql.apollo.exception.ApolloException;
-
-import javax.annotation.Nonnull;
 
 public class UpdatePostActivity extends AppCompatActivity {
     private static ListPostsQuery.ListPost sPost;

--- a/app/src/main/res/layout/activity_posts.xml
+++ b/app/src/main/res/layout/activity_posts.xml
@@ -1,26 +1,26 @@
 <?xml version="1.0" encoding="utf-8"?>
-<android.support.design.widget.CoordinatorLayout
+<androidx.coordinatorlayout.widget.CoordinatorLayout
     xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     xmlns:app="http://schemas.android.com/apk/res-auto">
 
-    <android.support.v4.widget.SwipeRefreshLayout
+    <androidx.swiperefreshlayout.widget.SwipeRefreshLayout
         xmlns:tools="http://schemas.android.com/tools"
         android:id="@+id/refreshLayout"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         tools:context="com.amazonaws.postsapp.PostsActivity">
 
-        <android.support.v7.widget.RecyclerView
+        <androidx.recyclerview.widget.RecyclerView
             android:id="@+id/my_recycler_view"
             android:layout_width="match_parent"
             android:layout_height="match_parent"
             android:scrollbars="vertical"/>
 
-    </android.support.v4.widget.SwipeRefreshLayout>
+    </androidx.swiperefreshlayout.widget.SwipeRefreshLayout>
 
-    <android.support.design.widget.FloatingActionButton
+    <com.google.android.material.floatingactionbutton.FloatingActionButton
         android:id="@+id/addPost"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
@@ -28,4 +28,4 @@
         android:layout_margin="16dp"
         android:tint="@android:color/white"
         app:srcCompat="@android:drawable/ic_input_add"/>
-</android.support.design.widget.CoordinatorLayout>
+</androidx.coordinatorlayout.widget.CoordinatorLayout>

--- a/aws-android-sdk-appsync-tests/build.gradle
+++ b/aws-android-sdk-appsync-tests/build.gradle
@@ -27,7 +27,7 @@ android {
         targetSdkVersion 28
         versionCode 1
         versionName "1.0"
-        testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
+        testInstrumentationRunner 'androidx.test.runner.AndroidJUnitRunner'
     }
 
     buildTypes {
@@ -53,9 +53,9 @@ repositories {
 }
 
 dependencies {
-    androidTestImplementation 'com.android.support:support-compat:28.0.0'
-    androidTestImplementation 'com.android.support.test:runner:1.0.2'
-    androidTestImplementation 'com.android.support.test.uiautomator:uiautomator-v18:2.1.3'
+    androidTestImplementation 'androidx.core:core:1.0.0'
+    androidTestImplementation 'androidx.test:runner:1.1.0'
+    androidTestImplementation 'androidx.test.uiautomator:uiautomator:2.2.0'
     androidTestImplementation 'junit:junit:4.13'
     androidTestImplementation "com.amazonaws:aws-android-sdk-s3:$aws_version"
     androidTestImplementation "com.amazonaws:aws-android-sdk-appsync:$VERSION_NAME"

--- a/aws-android-sdk-appsync-tests/src/androidTest/java/com/amazonaws/mobileconnectors/appsync/client/AWSAppSyncClients.java
+++ b/aws-android-sdk-appsync-tests/src/androidTest/java/com/amazonaws/mobileconnectors/appsync/client/AWSAppSyncClients.java
@@ -7,7 +7,7 @@
 
 package com.amazonaws.mobileconnectors.appsync.client;
 
-import android.support.annotation.NonNull;
+import androidx.annotation.NonNull;
 import android.util.Log;
 
 import com.amazonaws.mobile.config.AWSConfiguration;
@@ -28,7 +28,7 @@ import org.json.JSONObject;
 
 import java.util.concurrent.TimeUnit;
 
-import static android.support.test.InstrumentationRegistry.getTargetContext;
+import static androidx.test.InstrumentationRegistry.getTargetContext;
 import static org.junit.Assert.assertNotNull;
 
 /**

--- a/aws-android-sdk-appsync-tests/src/androidTest/java/com/amazonaws/mobileconnectors/appsync/client/DelegatingGraphQLCallback.java
+++ b/aws-android-sdk-appsync-tests/src/androidTest/java/com/amazonaws/mobileconnectors/appsync/client/DelegatingGraphQLCallback.java
@@ -7,7 +7,7 @@
 
 package com.amazonaws.mobileconnectors.appsync.client;
 
-import android.support.annotation.NonNull;
+import androidx.annotation.NonNull;
 
 import com.amazonaws.mobileconnectors.appsync.util.Consumer;
 import com.apollographql.apollo.GraphQLCall;

--- a/aws-android-sdk-appsync-tests/src/androidTest/java/com/amazonaws/mobileconnectors/appsync/client/LatchedGraphQLCallback.java
+++ b/aws-android-sdk-appsync-tests/src/androidTest/java/com/amazonaws/mobileconnectors/appsync/client/LatchedGraphQLCallback.java
@@ -7,8 +7,8 @@
 
 package com.amazonaws.mobileconnectors.appsync.client;
 
-import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 
 import com.amazonaws.mobileconnectors.appsync.util.Await;
 import com.apollographql.apollo.GraphQLCall;

--- a/aws-android-sdk-appsync-tests/src/androidTest/java/com/amazonaws/mobileconnectors/appsync/client/LatchedSubscriptionCallback.java
+++ b/aws-android-sdk-appsync-tests/src/androidTest/java/com/amazonaws/mobileconnectors/appsync/client/LatchedSubscriptionCallback.java
@@ -7,8 +7,8 @@
 
 package com.amazonaws.mobileconnectors.appsync.client;
 
-import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 
 import com.amazonaws.mobileconnectors.appsync.AppSyncSubscriptionCall;
 import com.amazonaws.mobileconnectors.appsync.util.Await;

--- a/aws-android-sdk-appsync-tests/src/androidTest/java/com/amazonaws/mobileconnectors/appsync/client/NoOpGraphQLCallback.java
+++ b/aws-android-sdk-appsync-tests/src/androidTest/java/com/amazonaws/mobileconnectors/appsync/client/NoOpGraphQLCallback.java
@@ -7,7 +7,7 @@
 
 package com.amazonaws.mobileconnectors.appsync.client;
 
-import android.support.annotation.NonNull;
+import androidx.annotation.NonNull;
 
 import com.apollographql.apollo.GraphQLCall;
 import com.apollographql.apollo.api.Response;

--- a/aws-android-sdk-appsync-tests/src/androidTest/java/com/amazonaws/mobileconnectors/appsync/identity/CustomCognitoUserPool.java
+++ b/aws-android-sdk-appsync-tests/src/androidTest/java/com/amazonaws/mobileconnectors/appsync/identity/CustomCognitoUserPool.java
@@ -7,7 +7,10 @@
 
 package com.amazonaws.mobileconnectors.appsync.identity;
 
-import android.support.annotation.NonNull;
+import static androidx.test.InstrumentationRegistry.getTargetContext;
+
+import androidx.annotation.NonNull;
+
 import android.util.Log;
 
 import com.amazonaws.mobile.client.results.SignInResult;
@@ -21,8 +24,6 @@ import com.amazonaws.mobileconnectors.cognitoidentityprovider.continuations.Auth
 import com.amazonaws.mobileconnectors.cognitoidentityprovider.continuations.ChallengeContinuation;
 import com.amazonaws.mobileconnectors.cognitoidentityprovider.continuations.MultiFactorAuthenticationContinuation;
 import com.amazonaws.mobileconnectors.cognitoidentityprovider.handlers.AuthenticationHandler;
-
-import static android.support.test.InstrumentationRegistry.getTargetContext;
 
 public final class CustomCognitoUserPool {
     private static final String TAG = CustomCognitoUserPool.class.getSimpleName();

--- a/aws-android-sdk-appsync-tests/src/androidTest/java/com/amazonaws/mobileconnectors/appsync/identity/DelayedCognitoCredentialsProvider.java
+++ b/aws-android-sdk-appsync-tests/src/androidTest/java/com/amazonaws/mobileconnectors/appsync/identity/DelayedCognitoCredentialsProvider.java
@@ -8,7 +8,8 @@
 package com.amazonaws.mobileconnectors.appsync.identity;
 
 import android.content.Context;
-import android.support.test.InstrumentationRegistry;
+
+import androidx.test.InstrumentationRegistry;
 
 import com.amazonaws.auth.AWSCredentials;
 import com.amazonaws.auth.AWSCredentialsProvider;

--- a/aws-android-sdk-appsync-tests/src/androidTest/java/com/amazonaws/mobileconnectors/appsync/identity/DelegatingMobileClientCallback.java
+++ b/aws-android-sdk-appsync-tests/src/androidTest/java/com/amazonaws/mobileconnectors/appsync/identity/DelegatingMobileClientCallback.java
@@ -1,6 +1,6 @@
 package com.amazonaws.mobileconnectors.appsync.identity;
 
-import android.support.annotation.Nullable;
+import androidx.annotation.Nullable;
 
 import com.amazonaws.mobile.client.Callback;
 import com.amazonaws.mobileconnectors.appsync.util.Consumer;

--- a/aws-android-sdk-appsync-tests/src/androidTest/java/com/amazonaws/mobileconnectors/appsync/identity/TestAWSMobileClient.java
+++ b/aws-android-sdk-appsync-tests/src/androidTest/java/com/amazonaws/mobileconnectors/appsync/identity/TestAWSMobileClient.java
@@ -8,7 +8,7 @@
 package com.amazonaws.mobileconnectors.appsync.identity;
 
 import android.content.Context;
-import android.support.annotation.NonNull;
+import androidx.annotation.NonNull;
 
 import com.amazonaws.mobile.client.AWSMobileClient;
 import com.amazonaws.mobile.client.UserStateDetails;

--- a/aws-android-sdk-appsync-tests/src/androidTest/java/com/amazonaws/mobileconnectors/appsync/tests/ComplexObjectsInstrumentationTests.java
+++ b/aws-android-sdk-appsync-tests/src/androidTest/java/com/amazonaws/mobileconnectors/appsync/tests/ComplexObjectsInstrumentationTests.java
@@ -7,7 +7,6 @@
 
 package com.amazonaws.mobileconnectors.appsync.tests;
 
-import android.support.test.runner.AndroidJUnit4;
 
 import com.amazonaws.mobileconnectors.appsync.AWSAppSyncClient;
 import com.amazonaws.mobileconnectors.appsync.client.AWSAppSyncClients;
@@ -37,6 +36,8 @@ import java.util.concurrent.CountDownLatch;
 import static com.amazonaws.mobileconnectors.appsync.util.InternetConnectivity.goOnline;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+
+import androidx.test.runner.AndroidJUnit4;
 
 /**
  * Instrumented test, which will execute on an Android device.

--- a/aws-android-sdk-appsync-tests/src/androidTest/java/com/amazonaws/mobileconnectors/appsync/tests/ConflictManagementInstrumentationTest.java
+++ b/aws-android-sdk-appsync-tests/src/androidTest/java/com/amazonaws/mobileconnectors/appsync/tests/ConflictManagementInstrumentationTest.java
@@ -7,8 +7,6 @@
 
 package com.amazonaws.mobileconnectors.appsync.tests;
 
-import android.support.test.runner.AndroidJUnit4;
-
 import com.amazonaws.mobileconnectors.appsync.AWSAppSyncClient;
 import com.amazonaws.mobileconnectors.appsync.client.AWSAppSyncClients;
 import com.amazonaws.mobileconnectors.appsync.client.LatchedGraphQLCallback;
@@ -27,6 +25,8 @@ import org.junit.runner.RunWith;
 import static com.amazonaws.mobileconnectors.appsync.util.InternetConnectivity.goOnline;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+
+import androidx.test.runner.AndroidJUnit4;
 
 /**
  * Instrumented test, which will execute on an Android device.

--- a/aws-android-sdk-appsync-tests/src/androidTest/java/com/amazonaws/mobileconnectors/appsync/tests/MultiClientInstrumentationTest.java
+++ b/aws-android-sdk-appsync-tests/src/androidTest/java/com/amazonaws/mobileconnectors/appsync/tests/MultiClientInstrumentationTest.java
@@ -7,7 +7,8 @@
 
 package com.amazonaws.mobileconnectors.appsync.tests;
 
-import android.support.test.runner.AndroidJUnit4;
+import static androidx.test.InstrumentationRegistry.getTargetContext;
+
 import android.util.Log;
 
 import com.amazonaws.mobile.client.AWSMobileClient;
@@ -49,7 +50,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import static android.support.test.InstrumentationRegistry.getTargetContext;
 import static com.amazonaws.mobileconnectors.appsync.util.InternetConnectivity.goOffline;
 import static com.amazonaws.mobileconnectors.appsync.util.InternetConnectivity.goOnline;
 import static org.junit.Assert.assertEquals;
@@ -59,6 +59,8 @@ import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
+
+import androidx.test.runner.AndroidJUnit4;
 
 /**
  * Instrumented test, which will execute on an Android device.

--- a/aws-android-sdk-appsync-tests/src/androidTest/java/com/amazonaws/mobileconnectors/appsync/tests/QueryInstrumentationTest.java
+++ b/aws-android-sdk-appsync-tests/src/androidTest/java/com/amazonaws/mobileconnectors/appsync/tests/QueryInstrumentationTest.java
@@ -7,7 +7,7 @@
 
 package com.amazonaws.mobileconnectors.appsync.tests;
 
-import android.support.annotation.NonNull;
+import androidx.annotation.NonNull;
 import android.util.Log;
 
 import com.amazonaws.mobileconnectors.appsync.AWSAppSyncClient;

--- a/aws-android-sdk-appsync-tests/src/androidTest/java/com/amazonaws/mobileconnectors/appsync/util/AirplaneMode.java
+++ b/aws-android-sdk-appsync-tests/src/androidTest/java/com/amazonaws/mobileconnectors/appsync/util/AirplaneMode.java
@@ -6,16 +6,16 @@
  */
 package com.amazonaws.mobileconnectors.appsync.util;
 
+import static androidx.test.InstrumentationRegistry.getInstrumentation;
+
 import android.content.ContentResolver;
 import android.content.Intent;
 import android.provider.Settings;
 
-import android.support.test.uiautomator.By;
-import android.support.test.uiautomator.BySelector;
-import android.support.test.uiautomator.UiDevice;
-import android.support.test.uiautomator.Until;
-
-import static android.support.test.InstrumentationRegistry.getInstrumentation;
+import androidx.test.uiautomator.By;
+import androidx.test.uiautomator.BySelector;
+import androidx.test.uiautomator.UiDevice;
+import androidx.test.uiautomator.Until;
 
 public final class AirplaneMode {
     private static final int TIMEOUT_MS = 500;

--- a/aws-android-sdk-appsync-tests/src/androidTest/java/com/amazonaws/mobileconnectors/appsync/util/Await.java
+++ b/aws-android-sdk-appsync-tests/src/androidTest/java/com/amazonaws/mobileconnectors/appsync/util/Await.java
@@ -7,7 +7,7 @@
 
 package com.amazonaws.mobileconnectors.appsync.util;
 
-import android.support.annotation.NonNull;
+import androidx.annotation.NonNull;
 
 import java.util.Objects;
 import java.util.concurrent.CountDownLatch;

--- a/aws-android-sdk-appsync-tests/src/androidTest/java/com/amazonaws/mobileconnectors/appsync/util/DataFile.java
+++ b/aws-android-sdk-appsync-tests/src/androidTest/java/com/amazonaws/mobileconnectors/appsync/util/DataFile.java
@@ -7,8 +7,8 @@
 package com.amazonaws.mobileconnectors.appsync.util;
 
 import android.content.Context;
-import android.support.annotation.NonNull;
-import android.support.test.InstrumentationRegistry;
+import androidx.annotation.NonNull;
+import androidx.test.InstrumentationRegistry;
 
 import java.io.File;
 import java.io.FileOutputStream;

--- a/aws-android-sdk-appsync/build.gradle
+++ b/aws-android-sdk-appsync/build.gradle
@@ -53,8 +53,7 @@ dependencies {
     implementation ("com.amazonaws:aws-android-sdk-mobile-client:$aws_version@aar") { transitive = true }
     implementation ("com.amazonaws:aws-android-sdk-auth-userpools:$aws_version@aar") { transitive = true }
 
-    def lifecycle_version = "1.1.1"
-    implementation("android.arch.lifecycle:runtime:$lifecycle_version")
+    implementation 'androidx.lifecycle:lifecycle-runtime:2.0.0'
 }
 
 project.afterEvaluate {

--- a/aws-android-sdk-appsync/src/main/java/com/amazonaws/mobileconnectors/appsync/AWSAppSyncAppLifecycleObserver.java
+++ b/aws-android-sdk-appsync/src/main/java/com/amazonaws/mobileconnectors/appsync/AWSAppSyncAppLifecycleObserver.java
@@ -7,9 +7,9 @@
 
 package com.amazonaws.mobileconnectors.appsync;
 
-import android.arch.lifecycle.Lifecycle;
-import android.arch.lifecycle.LifecycleObserver;
-import android.arch.lifecycle.OnLifecycleEvent;
+import androidx.lifecycle.Lifecycle;
+import androidx.lifecycle.LifecycleObserver;
+import androidx.lifecycle.OnLifecycleEvent;
 import android.util.Log;
 
 public class AWSAppSyncAppLifecycleObserver implements LifecycleObserver {

--- a/aws-android-sdk-appsync/src/main/java/com/amazonaws/mobileconnectors/appsync/AWSAppSyncClient.java
+++ b/aws-android-sdk-appsync/src/main/java/com/amazonaws/mobileconnectors/appsync/AWSAppSyncClient.java
@@ -9,7 +9,7 @@ package com.amazonaws.mobileconnectors.appsync;
 
 import android.content.Context;
 import android.content.SharedPreferences;
-import android.support.annotation.NonNull;
+import androidx.annotation.NonNull;
 import android.util.Log;
 
 import com.amazonaws.auth.AWSCredentialsProvider;

--- a/aws-android-sdk-appsync/src/main/java/com/amazonaws/mobileconnectors/appsync/AppSyncWebSocketSubscriptionCall.java
+++ b/aws-android-sdk-appsync/src/main/java/com/amazonaws/mobileconnectors/appsync/AppSyncWebSocketSubscriptionCall.java
@@ -7,7 +7,7 @@
 
 package com.amazonaws.mobileconnectors.appsync;
 
-import android.support.annotation.NonNull;
+import androidx.annotation.NonNull;
 
 import com.apollographql.apollo.api.Operation;
 import com.apollographql.apollo.api.Subscription;

--- a/aws-android-sdk-appsync/src/main/java/com/amazonaws/mobileconnectors/appsync/ConnectivityWatcher.java
+++ b/aws-android-sdk-appsync/src/main/java/com/amazonaws/mobileconnectors/appsync/ConnectivityWatcher.java
@@ -9,7 +9,7 @@ import android.net.Network;
 import android.net.NetworkInfo;
 import android.net.NetworkRequest;
 import android.os.Build;
-import android.support.annotation.RequiresApi;
+import androidx.annotation.RequiresApi;
 
 class ConnectivityWatcher {
 

--- a/aws-android-sdk-appsync/src/main/java/com/amazonaws/mobileconnectors/appsync/WebSocketConnectionManager.java
+++ b/aws-android-sdk-appsync/src/main/java/com/amazonaws/mobileconnectors/appsync/WebSocketConnectionManager.java
@@ -12,7 +12,7 @@ import android.net.Uri;
 import android.os.Handler;
 import android.os.HandlerThread;
 import android.os.Message;
-import android.support.annotation.NonNull;
+import androidx.annotation.NonNull;
 import android.util.Base64;
 import android.util.Log;
 

--- a/aws-android-sdk-appsync/src/test/java/com/amazonaws/mobileconnectors/appsync/retry/RetryInterceptorTest.java
+++ b/aws-android-sdk-appsync/src/test/java/com/amazonaws/mobileconnectors/appsync/retry/RetryInterceptorTest.java
@@ -7,7 +7,7 @@
 
 package com.amazonaws.mobileconnectors.appsync.retry;
 
-import android.support.annotation.NonNull;
+import androidx.annotation.NonNull;
 
 import com.amazonaws.mobileconnectors.appsync.util.Await;
 
@@ -20,8 +20,6 @@ import org.robolectric.RobolectricTestRunner;
 import org.robolectric.annotation.Config;
 
 import java.io.IOException;
-import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Consumer;
 

--- a/aws-android-sdk-appsync/src/test/java/com/amazonaws/mobileconnectors/appsync/util/Await.java
+++ b/aws-android-sdk-appsync/src/test/java/com/amazonaws/mobileconnectors/appsync/util/Await.java
@@ -7,7 +7,7 @@
 
 package com.amazonaws.mobileconnectors.appsync.util;
 
-import android.support.annotation.NonNull;
+import androidx.annotation.NonNull;
 
 import java.util.Objects;
 import java.util.concurrent.CountDownLatch;

--- a/gradle.properties
+++ b/gradle.properties
@@ -28,3 +28,7 @@ POM_LICENCE_DIST=repo
 POM_DEVELOPER_ID=amazonwebservices
 POM_DEVELOPER_ORGANIZATION=Amazon Web Services
 POM_DEVELOPER_ORGANIZATION_URL=http://aws.amazon.com
+
+# AndroidX
+android.useAndroidX=true
+android.enableJetifier=true


### PR DESCRIPTION
*Issue #, if available:*
#201 

*Description of changes:*

Task
---
AndroidX has been released a few years ago and most apps have already migrated to use AndroidX libraries.
Currently, many apps have already updated most of their dependencies to newer versions that use AndroidX and want to remove the AndroidX Jetifier process from their build to improve build performance.
The AndroidX Jetifier has performance issues and it's not cachable. It needs to process all dependencies regardless if they were migrated to AndroidX or not. So, this adds significant build time for large projects.

Solution
---
Migrate to AndroidX - update dependencies and imports from `android.support` to `androidx` package using Android Studio's automated refactoring and some manual adjustments.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
