### PR TITLE
fix for correctly JSON-marshalling subscription input variables within WebSocketConnectionManager

### DIFF
--- a/aws-android-sdk-appsync/src/main/java/com/amazonaws/mobileconnectors/appsync/AWSAppSyncClient.java
+++ b/aws-android-sdk-appsync/src/main/java/com/amazonaws/mobileconnectors/appsync/AWSAppSyncClient.java
@@ -270,6 +270,7 @@ public class AWSAppSyncClient {
             builder.mServerUrl,
             subscriptionAuthorizer,
             new ApolloResponseBuilder(builder.customTypeAdapters, mApolloClient.apolloStore().networkResponseNormalizer()),
+            new ScalarTypeAdapters(builder.customTypeAdapters),
             builder.mSubscriptionsAutoReconnect);
     }
 

--- a/aws-android-sdk-appsync/src/test/java/com/amazonaws/mobileconnectors/appsync/WebSocketConnectionManagerTest.java
+++ b/aws-android-sdk-appsync/src/test/java/com/amazonaws/mobileconnectors/appsync/WebSocketConnectionManagerTest.java
@@ -1,0 +1,105 @@
+package com.amazonaws.mobileconnectors.appsync;
+
+import android.content.Context;
+
+import com.amazonaws.mobileconnectors.appsync.util.subscriptions.EnumFieldSubscription;
+import com.amazonaws.mobileconnectors.appsync.util.subscriptions.TestEnum;
+import com.apollographql.apollo.api.Subscription;
+import com.google.gson.Gson;
+
+import org.json.JSONException;
+import org.json.JSONObject;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mockito;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.annotation.Config;
+
+import java.lang.reflect.Field;
+
+import okhttp3.WebSocket;
+
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.fail;
+
+/**
+ * tests for WebSocketConnectionManager
+ */
+@RunWith(RobolectricTestRunner.class)
+@Config(manifest = Config.NONE, sdk = 28)
+public class WebSocketConnectionManagerTest {
+
+    Context mockContext;
+    Subscription<?, ?, ?> testSubscription;
+    AppSyncSubscriptionCall.Callback mockCallback;
+    WebSocketConnectionManager webSocketConnectionManager;
+    SubscriptionAuthorizer mockSubscriptionAuthorizer;
+    WebSocket mockWebSocket;
+
+    @Before
+    public void beforeEachTest() {
+        // set up mocks
+        mockContext = Mockito.mock(Context.class);
+        testSubscription = new EnumFieldSubscription(TestEnum.TEST_ENUM);
+        mockCallback = Mockito.mock(AppSyncSubscriptionCall.Callback.class);
+        mockWebSocket = Mockito.mock(WebSocket.class);
+        mockSubscriptionAuthorizer = Mockito.mock(SubscriptionAuthorizer.class);
+        try {
+            Mockito.when(mockSubscriptionAuthorizer.getAuthorizationDetails(Mockito.anyBoolean(), Mockito.<Subscription>any())).thenReturn(null);
+        } catch (JSONException e) {
+            fail("This shouldn't happen.");
+        }
+
+        // set up webSocketConnectionManager
+        webSocketConnectionManager = new WebSocketConnectionManager(mockContext,
+                null,
+                mockSubscriptionAuthorizer,
+                null,
+                null,
+                true);
+
+        // set webSocketConnectionManager's websocket to mockWebSocket
+        try {
+            Field reader = WebSocketConnectionManager.class.getDeclaredField("websocket");
+            reader.setAccessible(true);
+            reader.set(webSocketConnectionManager, mockWebSocket);
+        } catch (NoSuchFieldException e) {
+            fail("WebSocketConnectionManager's websocket field has changed.");
+        } catch (IllegalAccessException e) {
+            fail("This shouldn't happen.");
+        }
+    }
+
+    /**
+     * Test to check whether a subscription request from [webSocketConnectionManager] will correctly
+     * marshall the enum field of the [EnumFieldSubscription]. If the "testEnum" field of the JSON
+     * string sent to the mockWebSocket is null, this test will fail.
+     */
+    @Test
+    public void testWebSocketConnectionManagerCorrectlyMarshalsSubscriptionsWithEnums() {
+        webSocketConnectionManager.requestSubscription(testSubscription, mockCallback);
+        ArgumentCaptor<String> sentStringCaptor = ArgumentCaptor.forClass(String.class);
+        Mockito.verify(mockWebSocket).send(sentStringCaptor.capture());
+
+        try {
+            JSONObject sentJSON = new JSONObject(sentStringCaptor.getValue());
+            JSONObject payload = sentJSON.getJSONObject("payload");
+            String data = payload.getString("data");
+            EnumFieldTestSubscriptionData subscriptionData = new Gson().fromJson(data, EnumFieldTestSubscriptionData.class);
+            assertNotNull(subscriptionData.variables.testEnum);
+        } catch (JSONException e) {
+            fail("invalid JSON was sent: " + e.getLocalizedMessage());
+        }
+    }
+
+    static class EnumFieldTestSubscriptionData {
+        String query;
+        EnumFieldTestVariables variables;
+
+        static class EnumFieldTestVariables {
+            String testEnum;
+        }
+    }
+}

--- a/aws-android-sdk-appsync/src/test/java/com/amazonaws/mobileconnectors/appsync/util/subscriptions/EnumFieldSubscription.java
+++ b/aws-android-sdk-appsync/src/test/java/com/amazonaws/mobileconnectors/appsync/util/subscriptions/EnumFieldSubscription.java
@@ -1,0 +1,105 @@
+package com.amazonaws.mobileconnectors.appsync.util.subscriptions;
+
+import com.apollographql.apollo.api.InputFieldMarshaller;
+import com.apollographql.apollo.api.InputFieldWriter;
+import com.apollographql.apollo.api.Operation;
+import com.apollographql.apollo.api.OperationName;
+import com.apollographql.apollo.api.ResponseFieldMapper;
+import com.apollographql.apollo.api.ResponseFieldMarshaller;
+import com.apollographql.apollo.api.Subscription;
+import com.apollographql.apollo.api.internal.Utils;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import javax.annotation.Nonnull;
+
+/**
+ * A testing class of a subscription with an enum field. Follows how apollo-generated subscriptions
+ * would generate (as of 3.1.4) - with some methods removed that aren't relevant to testing.
+ */
+public final class EnumFieldSubscription implements Subscription<EnumFieldSubscription.Data, EnumFieldSubscription.Data, EnumFieldSubscription.Variables> {
+
+  private final Variables variables;
+
+  private static final OperationName OPERATION_NAME = new OperationName() {
+    @Override
+    public String name() {
+      return "";
+    }
+  };
+
+  public EnumFieldSubscription(@Nonnull TestEnum testEnum) {
+    Utils.checkNotNull(testEnum, "testEnum == null");
+    variables = new Variables(testEnum);
+  }
+
+  @Override
+  public String operationId() { return ""; }
+
+  @Override
+  public String queryDocument() {
+    return "";
+  }
+
+  @Override
+  public Data wrapData(Data data) {
+    return data;
+  }
+
+  @Override
+  public Variables variables() {
+    return variables;
+  }
+
+  @Override
+  public ResponseFieldMapper<Data> responseFieldMapper() {
+    return null;
+  }
+
+  @Override
+  public OperationName name() {
+    return OPERATION_NAME;
+  }
+
+  public static final class Variables extends Operation.Variables {
+
+    private final @Nonnull TestEnum testEnum;
+
+    private final transient Map<String, Object> valueMap = new LinkedHashMap<>();
+
+    Variables(@Nonnull TestEnum testEnum) {
+      this.testEnum = testEnum;
+      this.valueMap.put("testEnum", testEnum);
+    }
+
+    public @Nonnull TestEnum testEnum() {
+      return testEnum;
+    }
+
+    @Override
+    public Map<String, Object> valueMap() {
+      return Collections.unmodifiableMap(valueMap);
+    }
+
+    @Override
+    public InputFieldMarshaller marshaller() {
+      return new InputFieldMarshaller() {
+        @Override
+        public void marshal(InputFieldWriter writer) throws IOException {
+          writer.writeString("testEnum", testEnum.name());
+        }
+      };
+    }
+  }
+
+  public static class Data implements Operation.Data {
+
+    @Override
+    public ResponseFieldMarshaller marshaller() {
+      return null;
+    }
+  }
+}

--- a/aws-android-sdk-appsync/src/test/java/com/amazonaws/mobileconnectors/appsync/util/subscriptions/TestEnum.java
+++ b/aws-android-sdk-appsync/src/test/java/com/amazonaws/mobileconnectors/appsync/util/subscriptions/TestEnum.java
@@ -1,0 +1,8 @@
+package com.amazonaws.mobileconnectors.appsync.util.subscriptions;
+
+/**
+ * a very simple enum class for testing
+ */
+public enum TestEnum {
+    TEST_ENUM
+}


### PR DESCRIPTION
Issue #, if available:
#352

Note:
This PR has been moved from my own fork to this.
Original PR: https://github.com/awslabs/aws-mobile-appsync-sdk-android/pull/351

Description of changes:
The startSubscription method in WebSocketConnectionManager now attempts to marshal subscription variables using the generated marshaller rather than just trying to call JSONObject(map) over the subscription's valueMap. More information about the bug attached in the issue.

startSubscription now adds the 'data' JSON field with a value equal to what is returned from htttpRequestBody(subscription).

httpRequestBody is a slightly modified version of the httpRequestBody method from AppSyncOfflineMutationManager. An extension has been made on the function to handle IOException's by reverting to the old way of creating the field's value (i.e. with a JSONObject(map) over the valueMap). This defense still can throw a JSONException however that is already handled by the caller function (startSubscription)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
