### PR TITLE
Add support for Gradle 7 projects

### DIFF
--- a/aws-android-sdk-appsync-gradle-plugin/src/main/java/com/apollographql/apollo/gradle/ApolloClassGenTask.java
+++ b/aws-android-sdk-appsync-gradle-plugin/src/main/java/com/apollographql/apollo/gradle/ApolloClassGenTask.java
@@ -29,7 +29,7 @@ public class ApolloClassGenTask extends SourceTask {
   @Internal private String variant;
   @Internal private ApolloExtension apolloExtension;
   @OutputDirectory private File outputDir;
-  private NullableValueType nullableValueType;
+  @Internal private NullableValueType nullableValueType;
 
   public void init(String variant, ApolloExtension apolloExtension) {
     this.variant = variant;


### PR DESCRIPTION
*Issue #, if available:*
#360 

*Description of changes:*
Gradle 7 requires a property of a task to have an annotation of input/output/internal.
It fails to compile Android projects using Gradle 7 and AGP 7. 

This PR adds the `@Internal` annotation to a private property of ApolloClassGenTask which fixes the compilation error with minimal changes.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
