### PR TITLE
Fix generating enums

### DIFF
--- a/aws-android-sdk-appsync-compiler/src/main/kotlin/com/apollographql/apollo/compiler/ResponseFieldSpec.kt
+++ b/aws-android-sdk-appsync-compiler/src/main/kotlin/com/apollographql/apollo/compiler/ResponseFieldSpec.kt
@@ -99,11 +99,15 @@ class ResponseFieldSpec(
 
   private fun readEnumCode(readerParam: CodeBlock, fieldParam: CodeBlock): CodeBlock {
     val readValueCode = CodeBlock.builder()
-        .addStatement("final \$T \$L", normalizedFieldSpec.type, fieldSpec.name)
+        .addStatement("\$T \$L", normalizedFieldSpec.type, fieldSpec.name)
         .beginControlFlow("if (\$LStr != null)", fieldSpec.name)
+        .beginControlFlow("try")
         .addStatement("\$L = \$T.valueOf(\$LStr)", fieldSpec.name, normalizedFieldSpec.type, fieldSpec.name)
+        .nextControlFlow("catch (IllegalArgumentException exception)")
+        .addStatement("\$L = \$T.UNKNOWN", fieldSpec.name, normalizedFieldSpec.type)
+        .endControlFlow()
         .nextControlFlow("else")
-        .addStatement("\$L = null", fieldSpec.name)
+        .addStatement("\$L = \$T.UNKNOWN", fieldSpec.name, normalizedFieldSpec.type)
         .endControlFlow()
         .build()
     return CodeBlock

--- a/aws-android-sdk-appsync-compiler/src/main/kotlin/com/apollographql/apollo/compiler/ir/TypeDeclaration.kt
+++ b/aws-android-sdk-appsync-compiler/src/main/kotlin/com/apollographql/apollo/compiler/ir/TypeDeclaration.kt
@@ -58,6 +58,7 @@ data class TypeDeclaration(
             .build()
         addEnumConstant(value.name, typeSpec)
       }
+      addEnumConstant("UNKNOWN")
       return this
     }
 


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/awslabs/aws-mobile-appsync-sdk-android/issues/349

*Description of changes:*
When somebody will add a new value for any Enum in the schema and will start sending it, apps will older schema will crash. I fixed the code generator to handle empty or unknown Enum values.
Fix:
1. I added UNKNOWN enum value to every generated enum.
2. UKNOWN will be set when the enum value is null (to by safe for kotlin) or some new one.

Old generated code:
```
final MyEnum something;
if (somethingStr != null) {
  something = MyEnum.valueOf(somethingStr);
} else {
  something = null;
}
```

New generated code:
```
MyEnum something;
if (somethingStr != null) {
  try {
    something = MyEnum.valueOf(somethingStr);
  } catch (IllegalArgumentException exception) {
    something = MyEnum.UNKNOWN;
  }
} else {
  something = MyEnum.UNKNOWN;
}
```


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
