### PR TITLE
feat: port custom domain support.

### DIFF
--- a/aws-android-sdk-appsync/src/main/java/com/amazonaws/mobileconnectors/appsync/DomainType.java
+++ b/aws-android-sdk-appsync/src/main/java/com/amazonaws/mobileconnectors/appsync/DomainType.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2021 Amazon.com,
+ * Inc. or its affiliates. All Rights Reserved.
+ * <p>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.amazonaws.mobileconnectors.appsync;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * The type of domain specified in API endpoint.
+ */
+enum DomainType {
+    /**
+     * Standard domain type composed of AWS AppSync endpoint where unique-id is made of 26 alphanumeric characters.
+     * See <a href="https://docs.aws.amazon.com/general/latest/gr/appsync.html">AppSync Endpoints</a>
+     */
+    STANDARD,
+
+    /**
+     * Custom domain defined by the user.
+     */
+    CUSTOM;
+
+    private static final String STANDARD_ENDPOINT_REGEX =
+            "^https://\\w{26}\\.appsync-api\\.\\w{2}(?:(?:-\\w{2,})+)-\\d\\.amazonaws.com/graphql$";
+
+    /**
+     * Get Domain type based on defined endpoint.
+     * @param endpoint Endpoint defined in config.
+     * @return {@link DomainType} based on supplied endpoint.
+     */
+    static DomainType from(String endpoint) {
+        if (isRegexMatch(endpoint)) {
+            return STANDARD;
+        }
+
+        return CUSTOM;
+    }
+
+    private static boolean isRegexMatch(String endpoint) {
+        final Pattern pattern = Pattern.compile(DomainType.STANDARD_ENDPOINT_REGEX, Pattern.CASE_INSENSITIVE);
+        final Matcher matcher = pattern.matcher(endpoint);
+
+        return matcher.matches();
+    }
+}

--- a/aws-android-sdk-appsync/src/main/java/com/amazonaws/mobileconnectors/appsync/SubscriptionAuthorizer.java
+++ b/aws-android-sdk-appsync/src/main/java/com/amazonaws/mobileconnectors/appsync/SubscriptionAuthorizer.java
@@ -133,6 +133,12 @@ class SubscriptionAuthorizer {
         }
 
         String apiRegion = apiUrl.getAuthority().split("\\.")[2];
+
+        DomainType domainType = DomainType.from(mServerUrl);
+        if (DomainType.CUSTOM == domainType) {
+            apiRegion = getApiRegion();
+        }
+
         if (connectionFlag){
             new AppSyncV4Signer(apiRegion, AppSyncV4Signer.ResourcePath.IAM_CONNECTION_RESOURCE_PATH)
                 .sign(canonicalRequest, getCredentialsProvider().getCredentials());
@@ -247,6 +253,11 @@ class SubscriptionAuthorizer {
          return mApiKeyProvider != null
                  ? mApiKeyProvider.getAPIKey()
                  : mAwsConfiguration.optJsonObject("AppSync").getString("ApiKey");
+    }
+
+    private String getApiRegion() throws JSONException {
+        return mAwsConfiguration.optJsonObject("AppSync")
+                .getString("Region");
     }
 
     /**

--- a/aws-android-sdk-appsync/src/main/java/com/amazonaws/mobileconnectors/appsync/WebSocketConnectionManager.java
+++ b/aws-android-sdk-appsync/src/main/java/com/amazonaws/mobileconnectors/appsync/WebSocketConnectionManager.java
@@ -398,11 +398,22 @@ final class WebSocketConnectionManager {
             throw new RuntimeException("Malformed Api Url: " + serverUrl);
         }
 
+        DomainType domainType = DomainType.from(serverUrl);
+
+        String authority = appSyncEndpoint.getHost();
+        if (domainType == DomainType.STANDARD) {
+            authority = authority.replace("appsync-api", "appsync-realtime-api");
+        }
+
+        String path = appSyncEndpoint.getPath();
+        if (domainType == DomainType.CUSTOM) {
+            path = path + "/realtime";
+        }
+
         return new Uri.Builder()
             .scheme("wss")
-            .authority(appSyncEndpoint.getHost()
-                .replace("appsync-api", "appsync-realtime-api"))
-            .appendPath(appSyncEndpoint.getPath())
+            .authority(authority)
+            .appendPath(path)
             .appendQueryParameter("header", Base64.encodeToString(rawHeader, Base64.DEFAULT))
             .appendQueryParameter("payload", "e30=")
             .build()

--- a/aws-android-sdk-appsync/src/test/java/com/amazonaws/mobileconnectors/appsync/AppSyncClientUnitTest.java
+++ b/aws-android-sdk-appsync/src/test/java/com/amazonaws/mobileconnectors/appsync/AppSyncClientUnitTest.java
@@ -119,7 +119,7 @@ public class AppSyncClientUnitTest {
                 "    \"OpenidConnect\": {\n" +
                 "      \"ApiUrl\": \"https://xxxx.appsync-api.us-east-1.amazonaws.com/graphql\",\n" +
                 "      \"Region\": \"us-east-1\",\n" +
-                "      \"AuthMode\": \"OPENID_CONNECT\"\n" +"" +
+                "      \"AuthMode\": \"OPENID_CONNECT\"\n" +
                 "    },\n" +
                 "    \"Lambda\": {\n" +
                 "      \"ApiUrl\": \"https://xxxx.appsync-api.us-east-1.amazonaws.com/graphql\",\n" +

--- a/aws-android-sdk-appsync/src/test/java/com/amazonaws/mobileconnectors/appsync/AppSyncClientUnitTest.java
+++ b/aws-android-sdk-appsync/src/test/java/com/amazonaws/mobileconnectors/appsync/AppSyncClientUnitTest.java
@@ -119,7 +119,12 @@ public class AppSyncClientUnitTest {
                 "    \"OpenidConnect\": {\n" +
                 "      \"ApiUrl\": \"https://xxxx.appsync-api.us-east-1.amazonaws.com/graphql\",\n" +
                 "      \"Region\": \"us-east-1\",\n" +
-                "      \"AuthMode\": \"OPENID_CONNECT\"\n" +
+                "      \"AuthMode\": \"OPENID_CONNECT\"\n" +"" +
+                "    },\n" +
+                "    \"Lambda\": {\n" +
+                "      \"ApiUrl\": \"https://xxxx.appsync-api.us-east-1.amazonaws.com/graphql\",\n" +
+                "      \"Region\": \"us-east-1\",\n" +
+                "      \"AuthMode\": \"AWS_LAMBDA\"\n" +
                 "    }\n" +
                 "  }\n" +
                 "}";
@@ -233,7 +238,7 @@ public class AppSyncClientUnitTest {
 
     @Test
     public void testAWSLambdaAuthProvider() {
-        awsConfiguration.setConfiguration("OpenidConnect");
+        awsConfiguration.setConfiguration("Lambda");
         final AWSAppSyncClient awsAppSyncClient = AWSAppSyncClient.builder()
                 .context(shadowContext)
                 .awsConfiguration(awsConfiguration)

--- a/aws-android-sdk-appsync/src/test/java/com/amazonaws/mobileconnectors/appsync/DomainTypeTest.java
+++ b/aws-android-sdk-appsync/src/test/java/com/amazonaws/mobileconnectors/appsync/DomainTypeTest.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2021 Amazon.com,
+ * Inc. or its affiliates. All Rights Reserved.
+ * <p>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.amazonaws.mobileconnectors.appsync;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class DomainTypeTest {
+    private static final String STANDARD_URL =
+            "https://abcdefghijklmnopqrstuvwxyz.appsync-api.us-west-2.amazonaws.com/graphql";
+    private static final String CUSTOM_URL = "https://something.in.somedomain.com/graphql";
+
+    /**
+     * Test that Domain type is {@link DomainType#STANDARD} for generated URL.
+     */
+    @Test
+    public void testStandardURLMatch() {
+        Assert.assertEquals(DomainType.STANDARD, DomainType.from(STANDARD_URL));
+    }
+
+    /**
+     * Test that Domain type is set to {@link DomainType#CUSTOM} for custom URLs.
+     */
+    @Test
+    public void testCustomURLMatch() {
+        Assert.assertEquals(DomainType.CUSTOM, DomainType.from(CUSTOM_URL));
+    }
+}


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Add the support to custom domain described in aws configuration. Existing functionality of appsync generated domains (with 26 char host) is not changed.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
