### PR TITLE
fix: ApolloServerInterceptor httpCall is now cloned to prevent "Illeg…

### DIFF
--- a/aws-android-sdk-appsync-runtime/src/main/java/com/apollographql/apollo/internal/interceptor/ApolloServerInterceptor.java
+++ b/aws-android-sdk-appsync-runtime/src/main/java/com/apollographql/apollo/internal/interceptor/ApolloServerInterceptor.java
@@ -88,7 +88,7 @@ import static com.apollographql.apollo.api.internal.Utils.checkNotNull;
           return;
         }
         if (httpCall != null) {
-            httpCall.enqueue(new Callback() {
+            httpCall.clone().enqueue(new Callback() {
                 @Override public void onFailure(@Nonnull Call call, @Nonnull IOException e) {
                     if (disposed) return;
                     logger.e(e, "Failed to execute http call for operation %s", request.operation.name().name());


### PR DESCRIPTION
fix: ApolloServerInterceptor HTTP call is now cloned to prevent "IllegalStateException: Already executed"

*Issue #, if available:*
IllegalStateException is raised when a Call is used multiple times

*Description of changes:*
 use call.clone().enqueue(..) for Asynchronous and call.clone().execute() for Synchronous respectively to ensure that you have a fresh, unexecuted Call for each request.

 <img width="1382" alt="Screen Shot 2022-03-23 at 1 41 43 PM" src="https://user-images.githubusercontent.com/16529074/159702167-3b446b2f-1def-4667-b70c-a39069d5fdfa.png">