### PR TITLE
fix-376/Add checks to prevent re-initialization of the connectivitywatcher

### DIFF
--- a/aws-android-sdk-appsync/src/main/java/com/amazonaws/mobileconnectors/appsync/AppSyncOfflineMutationManager.java
+++ b/aws-android-sdk-appsync/src/main/java/com/amazonaws/mobileconnectors/appsync/AppSyncOfflineMutationManager.java
@@ -81,8 +81,12 @@ class AppSyncOfflineMutationManager {
 
         //Setup Network Monitoring objects
         this.networkUpdateHandler = new NetworkUpdateHandler(handlerThread.getLooper());
-        this.connectivityWatcher = new ConnectivityWatcher(context,
-                new NetworkInfoReceiver(this.networkUpdateHandler));
+        if (this.connectivityWatcher == null) {
+            this.connectivityWatcher = new ConnectivityWatcher(context,
+                    new NetworkInfoReceiver(this.networkUpdateHandler));
+        } else {
+            this.connectivityWatcher.unregister();
+        }
         this.connectivityWatcher.register();
 
         //Setup ancillary stuff

--- a/aws-android-sdk-appsync/src/main/java/com/amazonaws/mobileconnectors/appsync/WebSocketConnectionManager.java
+++ b/aws-android-sdk-appsync/src/main/java/com/amazonaws/mobileconnectors/appsync/WebSocketConnectionManager.java
@@ -254,7 +254,11 @@ final class WebSocketConnectionManager {
                         if (isNetworkConnected) reportNetworkUp();
                     }
                 };
-                connectivityWatcher = new ConnectivityWatcher(applicationContext, callback);
+                if (connectivityWatcher == null) {
+                    connectivityWatcher = new ConnectivityWatcher(applicationContext, callback);
+                } else {
+                    connectivityWatcher.unregister();
+                }
                 connectivityWatcher.register();
             }
 


### PR DESCRIPTION
Add checks to prevent re-initialization of the connectivityWatcher and unregistering before registering the same watcher to prevent too manyrequests to networkcallback registeration

*Issue #376 

*Description of changes:*
- Added check for initialized connectivityWatcher and if already initialized, unregister the current listener before re-registering.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
