### PR TITLE
chore: upgrade jmespath to version 1.6.1

### DIFF
--- a/build-support/Gemfile.lock
+++ b/build-support/Gemfile.lock
@@ -151,7 +151,7 @@ GEM
     http-cookie (1.0.4)
       domain_name (~> 0.5)
     httpclient (2.8.3)
-    jmespath (1.4.0)
+    jmespath (1.6.1)
     json (2.5.1)
     jwt (2.2.3)
     memoist (0.16.2)


### PR DESCRIPTION
Fix error: Dependabot only supports uninterpolated string arguments to eval_gemfile. Got plugins_path

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
