### PR TITLE
Fix duplicate Nullable annotation

### DIFF
--- a/aws-android-sdk-appsync-compiler/src/main/kotlin/com/apollographql/apollo/compiler/Util.kt
+++ b/aws-android-sdk-appsync-compiler/src/main/kotlin/com/apollographql/apollo/compiler/Util.kt
@@ -24,7 +24,7 @@ fun String.escapeJavaReservedWord() = if (JAVA_RESERVED_WORDS.contains(this)) "$
 fun TypeName.overrideTypeName(typeNameOverrideMap: Map<String, String>): TypeName {
   if (this is ParameterizedTypeName) {
     val typeArguments = typeArguments.map { it.overrideTypeName(typeNameOverrideMap) }.toTypedArray()
-    return ParameterizedTypeName.get(rawType, *typeArguments)
+    return ParameterizedTypeName.get(rawType.overrideTypeName(typeNameOverrideMap) as ClassName, *typeArguments)
   } else if (this is ClassName) {
     return ClassName.get(packageName(), typeNameOverrideMap[simpleName()] ?: simpleName())
   } else if (this is WildcardTypeName) {

--- a/aws-android-sdk-appsync-compiler/src/main/kotlin/com/apollographql/apollo/compiler/Util.kt
+++ b/aws-android-sdk-appsync-compiler/src/main/kotlin/com/apollographql/apollo/compiler/Util.kt
@@ -24,7 +24,7 @@ fun String.escapeJavaReservedWord() = if (JAVA_RESERVED_WORDS.contains(this)) "$
 fun TypeName.overrideTypeName(typeNameOverrideMap: Map<String, String>): TypeName {
   if (this is ParameterizedTypeName) {
     val typeArguments = typeArguments.map { it.overrideTypeName(typeNameOverrideMap) }.toTypedArray()
-    return ParameterizedTypeName.get(rawType.overrideTypeName(typeNameOverrideMap) as ClassName, *typeArguments)
+    return ParameterizedTypeName.get(rawType.overrideTypeName(typeNameOverrideMap) as? ClassName, *typeArguments)
   } else if (this is ClassName) {
     return ClassName.get(packageName(), typeNameOverrideMap[simpleName()] ?: simpleName())
   } else if (this is WildcardTypeName) {


### PR DESCRIPTION
Fixes https://github.com/awslabs/aws-mobile-appsync-sdk-android/issues/395.  Javapoet v1.11 and higher store annotations on (parameterized) type objects as well as their underlying raw types (i.e. both on `List<Item>` and `Item`) so when rebuilding the type we need to clear both.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
