### PR TITLE
feat: Add support for Gradle 8

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ buildscript {
             url "https://plugins.gradle.org/m2/"
         }
         google()
-        jcenter()
+        mavenCentral()
     }
 }
 ```
@@ -57,7 +57,7 @@ allprojects {
             url "https://plugins.gradle.org/m2/"
         }
         google()
-        jcenter()
+        mavenCentral()
     }
 }
 ```
@@ -72,7 +72,7 @@ buildscript {
             url "https://plugins.gradle.org/m2/"
         }
         google()
-        jcenter()
+        mavenCentral()
     }
 
     dependencies {
@@ -87,7 +87,7 @@ allprojects {
             url "https://plugins.gradle.org/m2/"
         }
         google()
-        jcenter()
+        mavenCentral()
     }
 }
 

--- a/aws-android-sdk-appsync-gradle-plugin/src/main/java/com/apollographql/apollo/gradle/ApolloClassGenTask.java
+++ b/aws-android-sdk-appsync-gradle-plugin/src/main/java/com/apollographql/apollo/gradle/ApolloClassGenTask.java
@@ -77,7 +77,7 @@ public abstract class ApolloClassGenTask extends DefaultTask {
         ? NullableValueType.ANNOTATED
         : NullableValueType.Companion.findByValue(apolloExtension.getNullableValueType());
     outputDir = new File(getProject().getBuildDir() + File.separator + Joiner.on(File.separator).join(GraphQLCompiler.Companion
-        .getOUTPUT_DIRECTORY()));
+        .getOUTPUT_DIRECTORY()) + File.separator + variant);
   }
 
   @TaskAction

--- a/aws-android-sdk-appsync-gradle-plugin/src/main/java/com/apollographql/apollo/gradle/ApolloClassGenTask.java
+++ b/aws-android-sdk-appsync-gradle-plugin/src/main/java/com/apollographql/apollo/gradle/ApolloClassGenTask.java
@@ -7,28 +7,67 @@
 
 package com.apollographql.apollo.gradle;
 
+import static org.gradle.api.tasks.PathSensitivity.RELATIVE;
+
 import com.google.common.base.Joiner;
 
 import com.apollographql.apollo.compiler.GraphQLCompiler;
 import com.apollographql.apollo.compiler.NullableValueType;
 
 import org.gradle.api.Action;
+import org.gradle.api.DefaultTask;
+import org.gradle.api.file.ConfigurableFileCollection;
+import org.gradle.api.file.DirectoryProperty;
+import org.gradle.api.file.FileCollection;
+import org.gradle.api.file.FileTree;
+import org.gradle.api.file.FileType;
+import org.gradle.api.file.FileVisitDetails;
 import org.gradle.api.tasks.Input;
+import org.gradle.api.tasks.InputDirectory;
+import org.gradle.api.tasks.InputFiles;
 import org.gradle.api.tasks.Internal;
 import org.gradle.api.tasks.OutputDirectory;
+import org.gradle.api.tasks.PathSensitive;
+import org.gradle.api.tasks.PathSensitivity;
+import org.gradle.api.tasks.SkipWhenEmpty;
 import org.gradle.api.tasks.SourceTask;
 import org.gradle.api.tasks.TaskAction;
 import org.gradle.api.tasks.incremental.IncrementalTaskInputs;
 import org.gradle.api.tasks.incremental.InputFileDetails;
+import org.gradle.api.tasks.util.PatternFilterable;
+import org.gradle.api.tasks.util.PatternSet;
+import org.gradle.work.FileChange;
+import org.gradle.work.Incremental;
+import org.gradle.work.InputChanges;
 
 import java.io.File;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.Callable;
+import java.util.function.Consumer;
 
-public class ApolloClassGenTask extends SourceTask {
+public abstract class ApolloClassGenTask extends DefaultTask {
   static final String NAME = "generate%sApolloClasses";
 
   @Internal private String variant;
   @Internal private ApolloExtension apolloExtension;
+
+  private PatternFilterable pattern = new PatternSet();
+
+  private final ConfigurableFileCollection allSourceFiles = getProject().getObjects().fileCollection();
+
+  @InputFiles
+  @Incremental
+  @PathSensitive(RELATIVE)
+  private final ConfigurableFileCollection source = getProject().files().from(new Callable<FileTree>() {
+    @Override
+    public FileTree call() {
+      return allSourceFiles.getAsFileTree().matching(pattern);
+    }
+  });
+
   @OutputDirectory private File outputDir;
+
   @Internal private NullableValueType nullableValueType;
 
   public void init(String variant, ApolloExtension apolloExtension) {
@@ -42,22 +81,18 @@ public class ApolloClassGenTask extends SourceTask {
   }
 
   @TaskAction
-  void generateClasses(IncrementalTaskInputs inputs) {
-    inputs.outOfDate(new Action<InputFileDetails>() {
-      @Override
-      public void execute(InputFileDetails inputFileDetails) {
-        File inputFile = inputFileDetails.getFile();
-        if (!inputFile.isFile()) {
-          // skip if input is not a file
-          return;
-        }
-        GraphQLCompiler.Arguments args = new GraphQLCompiler.Arguments(inputFile, outputDir,
-            apolloExtension.getCustomTypeMapping(), nullableValueType, apolloExtension.isGenerateAccessors(),
-            apolloExtension.isUseSemanticNaming(), apolloExtension.isGenerateModelBuilder(),
-            apolloExtension.getOutputPackageName());
-        new GraphQLCompiler().write(args);
+  void generateClasses(InputChanges inputs) {
+    for (FileChange change : inputs.getFileChanges(getSource())) {
+      if (change.getFileType() != FileType.FILE) {
+        continue;
       }
-    });
+      File inputFile = change.getFile();
+      GraphQLCompiler.Arguments args = new GraphQLCompiler.Arguments(inputFile, outputDir,
+              apolloExtension.getCustomTypeMapping(), nullableValueType, apolloExtension.isGenerateAccessors(),
+              apolloExtension.isUseSemanticNaming(), apolloExtension.isGenerateModelBuilder(),
+              apolloExtension.getOutputPackageName());
+      new GraphQLCompiler().write(args);
+    }
   }
 
   public String getVariant() {
@@ -66,6 +101,17 @@ public class ApolloClassGenTask extends SourceTask {
 
   public void setVariant(String variant) {
     this.variant = variant;
+  }
+
+
+  public FileCollection getSource() { return source; }
+
+  public void setSource(Object source) {
+    allSourceFiles.setFrom(source);
+  }
+
+  public void setInclude(String... include) {
+    pattern.include(include);
   }
 
   public File getOutputDir() {
@@ -91,4 +137,5 @@ public class ApolloClassGenTask extends SourceTask {
   public void setApolloExtension(ApolloExtension apolloExtension) {
     this.apolloExtension = apolloExtension;
   }
+
 }

--- a/aws-android-sdk-appsync-tests/build.gradle
+++ b/aws-android-sdk-appsync-tests/build.gradle
@@ -10,7 +10,7 @@ buildscript {
             url "https://plugins.gradle.org/m2/"
         }
         google()
-        jcenter()
+        mavenCentral()
     }
 
     dependencies {
@@ -49,7 +49,7 @@ repositories {
         url "https://plugins.gradle.org/m2/"
     }
     google()
-    jcenter()
+    mavenCentral()
 }
 
 dependencies {
@@ -63,4 +63,3 @@ dependencies {
     androidTestImplementation ("com.amazonaws:aws-android-sdk-auth-userpools:$aws_version@aar") { transitive = true }
     androidTestImplementation ("com.amazonaws:aws-android-sdk-cognitoauth:$aws_version@aar")
 }
-

--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ buildscript {
             url "https://plugins.gradle.org/m2/"
         }
         google()
-        jcenter()
+        mavenCentral()
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:3.5.3'
@@ -22,7 +22,7 @@ allprojects {
             url "https://plugins.gradle.org/m2/"
         }
         google()
-        jcenter()
+        mavenCentral()
     }
 }
 
@@ -42,4 +42,3 @@ subprojects { project ->
 task clean(type: Delete) {
     delete rootProject.buildDir
 }
-


### PR DESCRIPTION
*Issue #, if available:* #410

*Description of changes:*
- Migrate `ApolloClassGenTask` away from the removed `IncrementalTaskInputs` API and use the `InputChanges` API instead (available since Gradle 5.4). `IncrementalTaskInputs` was deprecated in Gradle 6 and removed in Gradle 8. This required some other changes to `ApolloClassGenTask` as the `SourceTask` base class is not suitable to use with `InputChanges`.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
