### PR TITLE
chore: Set proper min sdk of 21

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,10 @@ For front-end web and mobile development, we recommend using the [Amplify](https
 
 The AWS AppSync SDK for Android enables you to access your AWS AppSync backend and perform operations like queries, mutations, and subscription. The SDK also includes support for offline operations. This SDK is derrived from the Apollo project found [here](https://github.com/apollographql/apollo-android). Please log questions for this client SDK in this repo and questions for the AppSync service in the [official AWS AppSync forum](https://forums.aws.amazon.com/forum.jspa?forumID=280&start=0).
 
+## Platform Support
+
+AWS AppSync SDK for Android supports Android API level 21 (Android 5.0) and above.
+
 ## Samples
 
 1. A sample app using the events sample schema can be found here: https://github.com/aws-samples/aws-mobile-appsync-events-starter-android

--- a/aws-android-sdk-appsync-tests/build.gradle
+++ b/aws-android-sdk-appsync-tests/build.gradle
@@ -23,7 +23,7 @@ android {
     compileSdkVersion 28
 
     defaultConfig {
-        minSdkVersion 18
+        minSdkVersion 21
         targetSdkVersion 28
         versionCode 1
         versionName "1.0"

--- a/aws-android-sdk-appsync/build.gradle
+++ b/aws-android-sdk-appsync/build.gradle
@@ -7,7 +7,7 @@ android {
     compileSdkVersion 28
 
     defaultConfig {
-        minSdkVersion 15
+        minSdkVersion 21
         targetSdkVersion 28
         versionCode 1
         versionName "1.0"


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
A minimum SDK version of 21 was enforced when upgrading OkHttp in this commit:
https://github.com/awslabs/aws-mobile-appsync-sdk-android/commit/83ed788b64e6ed35f42a653243b2e3f6b28bc022.

This means that all versions of the AppSync SDK have had min sdk support of 21 for ~ 3 years. This PR adds minimum support statement and allows builds to fail during compile, rather than runtime.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
