### PR TITLE
WEBrick patch upgrade for RCE Vulnerability 

### DIFF
--- a/build-support/Gemfile
+++ b/build-support/Gemfile
@@ -1,8 +1,9 @@
 source "https://rubygems.org"
 
+ruby "~> 2.2.8"
+
 gem "fastlane"
 gem "addressable", ">= 2.8.0"
-gem "webrick", ">= 2.2.8"
 
 plugins_path = File.join(File.dirname(__FILE__), 'fastlane', 'Pluginfile')
 eval_gemfile(plugins_path) if File.exist?(plugins_path)

--- a/build-support/Gemfile
+++ b/build-support/Gemfile
@@ -2,6 +2,7 @@ source "https://rubygems.org"
 
 gem "fastlane"
 gem "addressable", ">= 2.8.0"
+gem "webrick", ">= 2.2.8"
 
 plugins_path = File.join(File.dirname(__FILE__), 'fastlane', 'Pluginfile')
 eval_gemfile(plugins_path) if File.exist?(plugins_path)

--- a/build-support/Gemfile
+++ b/build-support/Gemfile
@@ -1,6 +1,6 @@
 source "https://rubygems.org"
 
-ruby "~> 2.2.8"
+ruby "2.2.8"
 
 gem "fastlane"
 gem "addressable", ">= 2.8.0"

--- a/build-support/Gemfile.lock
+++ b/build-support/Gemfile.lock
@@ -196,7 +196,7 @@ GEM
       unf_ext
     unf_ext (0.0.7.7)
     unicode-display_width (1.7.0)
-    webrick (1.7.0)
+    webrick (2.2.8)
     word_wrap (1.0.0)
     xcodeproj (1.21.0)
       CFPropertyList (>= 2.3.3, < 4.0)

--- a/build-support/Gemfile.lock
+++ b/build-support/Gemfile.lock
@@ -196,7 +196,7 @@ GEM
       unf_ext
     unf_ext (0.0.7.7)
     unicode-display_width (1.7.0)
-    webrick (2.2.8)
+    webrick (1.7.0)
     word_wrap (1.0.0)
     xcodeproj (1.21.0)
       CFPropertyList (>= 2.3.3, < 4.0)


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes: WEBrick RCE Vulnerability patch upgrade. Patch Version: 2.2.8


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
