### PR TITLE
fix: Update Node Version for Codegen

### DIFF
--- a/aws-android-sdk-appsync-gradle-plugin/src/main/groovy/com/apollographql/apollo/gradle/ApolloPlugin.groovy
+++ b/aws-android-sdk-appsync-gradle-plugin/src/main/groovy/com/apollographql/apollo/gradle/ApolloPlugin.groovy
@@ -30,7 +30,7 @@ import org.gradle.api.tasks.compile.JavaCompile
 import javax.inject.Inject
 
 class ApolloPlugin implements Plugin<Project> {
-    private static final String NODE_VERSION = "6.7.0"
+    private static final String NODE_VERSION = "20.10.0"
     public static final String TASK_GROUP = "apollo"
     private static final String AMAZON_DEP_GROUP = "com.amazonaws"
     private static final String RUNTIME_DEP_NAME = "aws-android-sdk-appsync-runtime"


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/awslabs/aws-mobile-appsync-sdk-android/issues/355

*Description of changes:*
Updates to use latest LTS version of node, which resolves Apple Silicon build errors.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
