### PR TITLE
fix: Release Prep Updates

### DIFF
--- a/.github/workflows/release_pr.yml
+++ b/.github/workflows/release_pr.yml
@@ -19,7 +19,7 @@ jobs:
         ref: ${{ env.BASE_BRANCH }}
         fetch-depth: 0
     - name: Set up Ruby
-      uses: ruby/setup-ruby@b8d447ba7506ac7e0c8fbc50762276fb3b7df731 # v1
+      uses: ruby/setup-ruby@8575951200e472d5f2d95c625da0c7bec8217c42 # v1
       with:
         ruby-version: 2.7
     - name: Install dependencies


### PR DESCRIPTION
update ruby/setup-ruby to fix broken links

https://github.com/ruby/setup-ruby/releases/tag/v1.161.0

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
