### PR TITLE
chore: Use Ruby 3.0 for the release PR workflow

### DIFF
--- a/.github/workflows/release_pr.yml
+++ b/.github/workflows/release_pr.yml
@@ -21,7 +21,7 @@ jobs:
     - name: Set up Ruby
       uses: ruby/setup-ruby@8575951200e472d5f2d95c625da0c7bec8217c42 # v1
       with:
-        ruby-version: 2.7
+        ruby-version: "3.0"
     - name: Install dependencies
       run: |
         cd build-support


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
This mimics the change to use Ruby 3.0 in the amplify-android repo: https://github.com/aws-amplify/amplify-android/pull/2661

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
